### PR TITLE
getting groups for a non-existent user should raise a ValueError

### DIFF
--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -118,9 +118,9 @@ class TestPloneApiGroup(unittest.TestCase):
         assert 'AuthenticatedUsers' in groups
         assert 'staff' in groups
 
-        self.assertRaises(ValueError, 
-            api.group.get_groups, 
-            username='theurbanspaceman')
+        self.assertRaises(ValueError,
+                          api.group.get_groups,
+                          username='theurbanspaceman')
 
     def test_delete_contraints(self):
         """ Test the contraints for deleting a group """


### PR DESCRIPTION
Just another little step towards full coverage. Subject says it all.
