### PR TITLE
Changelog, RST and declaring dependencies

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,5 +1,5 @@
-Changelog
-=========
+Changes
+=======
 
 0.1b2 (Unreleased)
 ------------------

--- a/docs/contribute/conventions.rst
+++ b/docs/contribute/conventions.rst
@@ -90,11 +90,11 @@ Declaring dependencies
 
 All direct dependencies should be declared in ``install_requires`` or
 ``extras_require`` sections in setup.py. Dependencies, which are not needed for
-an production environment (like "develop" or "test" dependencies) or are
+a production environment (like "develop" or "test" dependencies) or are
 optional (like "archetypes" or "dexterity" flavors of the same package) should
-go in ``extras_require``. Don't forget some documentation on how to enable
-specific features (and think of using ``zcml:condition`` statements, if you
-have such optional features).
+go in ``extras_require``. Remember to document how to enable specific features
+(and think of using ``zcml:condition`` statements, if you have such optional
+features).
 
 Generally all direct dependencies (packages directly imported or used in ZCML)
 should be declared, even if they would already pulled in by other dependencies.
@@ -134,12 +134,12 @@ This way you get nice syntax highlighting and formating in recent text editors,
 on GitHub and with Sphinx.
 
 
-.. _changelog:
+.. _changes:
 
-Changelog
-=========
+Tracking changes
+================
 
-Feature-level changes to code are tracked inside ``CHANGES.rst``. Examples:
+Feature-level changes to code are tracked inside ``docs/CHANGES.rst``. Example:
 
 .. sourcecode:: rst
 
@@ -164,7 +164,7 @@ Feature-level changes to code are tracked inside ``CHANGES.rst``. Examples:
 
 
 Add an entry every time you add/remove a feature, fix a bug, etc. on top of the
-current development changelog block.
+current development changes block.
 
 
 .. _sphinx-docs:

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -172,7 +172,7 @@ Commit checklist
 Before every commit you should:
 
 * Run unit tests and syntax validation checks.
-* Add an entry to :ref:`changelog` (if applicable).
+* Add an entry to :ref:`changes` (if applicable).
 * Add/modify :ref:`sphinx-docs` (if applicable).
 
 All syntax checks and all tests can be run with a single command. This

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -43,4 +43,4 @@ Description of our release process and guidelines.
    release.rst
 
 
-.. include:: ../../HISTORY.rst
+.. include:: ../../CHANGES.rst

--- a/docs/contribute/release.rst
+++ b/docs/contribute/release.rst
@@ -39,7 +39,7 @@ Checklist
 
 Folow these step to create a new release of `plone.api`.
 
-#. Verify that we have documented all changes in the ``HISTORY.rst`` file. Go
+#. Verify that we have documented all changes in the ``CHANGES.rst`` file. Go
    through the list of commits since last release on GitHub and check all
    changes are documented.
 


### PR DESCRIPTION
## On docs/HISTORY.txt vs CHANGES.txt

I'd actually prefer CHANGES.rst - the extension .rst for better syntax
highlighting (we have those files in ReST anyways) and CHANGES in the
package's top level directory, because we actually document changes
between releases and have not an historic essay. It just names the
purpose better, I'd say. I'm a non-native English speaker, so I might
be wrong.
docs/HISTORY.rst would be good for very long CHANGES.rst files, where
we might want just to have the changes since the last major version
release in.
## Prefer .rst over .txt for any documentation, even doctests

Just because of the nice syntax highlighting.
## Notes on how to declare dependencies
