### PR TITLE
Do not assume that plone.registry is installed

### DIFF
--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -21,7 +21,7 @@ logger = getLogger('plone.api.portal')
 try:
     from plone.registry.interfaces import IRegistry
 except ImportError:
-    logger.info('plone.registry is not installed.')
+    logger.warning('plone.registry is not installed. get_registry_record and set_registry_record will be unavailable.')
 
 
 def get():


### PR DESCRIPTION
Wrap the import of the IRegistry interface in a try/except as plone.registry is not part of plone 4.0 or 4.1
