### PR TITLE
do reuse the argument variable name in this list comprehension

### DIFF
--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -68,7 +68,8 @@ def create(
         container.invokeFactory(type, content_id, **kwargs)
     except ValueError:
         if ISiteRoot.providedBy(container):
-            types = [allowed_type.id for allowed_type in container.allowedContentTypes()]
+            allowed_types = container.allowedContentTypes()
+            types = [allowed_type.id for allowed_type in allowed_types]
         else:
             types = container.getLocallyAllowedTypes()
 


### PR DESCRIPTION
This should fix the issue where the incorrect type is returned when an item of content cannot be added to the plone site.
