### PR TITLE
do not assume we can acquire getLocallyAllowedTypes

### DIFF
--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -70,7 +70,12 @@ def create(
             allowed_types = container.allowedContentTypes()
             types = [allowed_type.id for allowed_type in allowed_types]
         else:
-            types = container.getLocallyAllowedTypes()
+            try:
+                types = container.getLocallyAllowedTypes()
+            except AttributeError:
+                raise InvalidParameterError(
+                    "Cannot add a '%s' object to the container." % type
+                )
 
         raise InvalidParameterError(
             "Cannot add a '{0}' object to the container.\n"


### PR DESCRIPTION
It seems in some test scenarios getLocallyAllowedTypes is not always available. In this case, instead of raising an AttributeError, raise an InvalidParameterError with a helpful error string.
