### PR TITLE
Use getPhysicalPath instead of absolute_url_path in api.content.get()

### DIFF
--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -130,7 +130,7 @@ def get(path=None, UID=None):
     """
     if path:
         site = portal.get()
-        site_absolute_path = site.absolute_url_path()
+        site_absolute_path = '/'.join(site.getPhysicalPath())
         if not path.startswith('{0}'.format(site_absolute_path)):
             path = '{0}{1}'.format(site_absolute_path, path)
 


### PR DESCRIPTION
This should fix #152. I haven't added any additional tests because this would be somewhat tricky to set up.. I have tested it manually with nginx/virtual host configuration as per [1].

[1] http://developer.plone.org/hosting/nginx.html#minimal-nginx-front-end-configuration-for-plone-on-ubuntu-debian-linux
