### PR TITLE
Catch AttributeError in ``api.content.get``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,13 @@ Changelog
 
 - Add ``api.env.plone_version()`` and ``api.env.zope_version()`` refs. #126.
   [hvelarde]
+
 - Stop UnicodeDecodeErrors being swallowed in ``api.content.create``
   [mattss]
 
+- Catch AttributeError in ``api.content.get`` (raised if only part of the
+  traversal path exists)
+  [mattss]
 
 1.1.0 (2013-10-12)
 ------------------

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -136,7 +136,7 @@ def get(path=None, UID=None):
 
         try:
             return site.restrictedTraverse(path)
-        except KeyError:
+        except (KeyError, AttributeError):
             return None  # When no object is found don't raise an error
 
     elif UID:

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -305,6 +305,9 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertFalse(api.content.get('/spam/ham'))
         self.assertFalse(api.content.get(UID='bacon'))
 
+        # Test getting a non-existing subfolder by path
+        self.assertFalse(api.content.get('/about/spam'))
+
     def test_move_constraints(self):
         """Test the constraints for moving content."""
         from plone.api.exc import MissingParameterError


### PR DESCRIPTION
unrestrictedTraverse raises an AttributeError if the first part of the path can be traversed. If we are catching KeyError here we should do the same for AttributeError.
