### PR TITLE
Limit the export of public objects

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -3,9 +3,16 @@ Changelog
 
 1.2.1 (2014-06-24)
 ------------------
+
+- Limit the export of public objects. This way is easier to find out API
+  methods and functions when using an interactive Python interpreter like
+  IPython or bpython.
+  [hvelarde]
+
 - Resolve issues with CHANGES.rst symlink that prevented 1.2.0 from
   being installed in some circumstances.
   [mattss]
+
 
 1.2.0 (2014-06-24)
 ------------------

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -21,6 +21,20 @@ from zope.interface import providedBy
 import random
 import transaction
 
+__all__ = [
+    'copy',
+    'create',
+    'delete',
+    'get',
+    'get',
+    'get_state',
+    'get_uuid',
+    'get_view',
+    'move',
+    'rename',
+    'transition',
+]
+
 
 @required_parameters('container', 'type')
 @at_least_one_of('id', 'title')

--- a/src/plone/api/env.py
+++ b/src/plone/api/env.py
@@ -15,6 +15,15 @@ from zope.globalrequest import getRequest
 import Globals
 import traceback
 
+__all__ = [
+    'adopt_roles',
+    'adopt_user',
+    'debug_mode',
+    'plone_version',
+    'test_mode',
+    'zope_version',
+]
+
 IS_TEST = None
 
 

--- a/src/plone/api/group.py
+++ b/src/plone/api/group.py
@@ -9,6 +9,17 @@ from plone.api.validation import at_least_one_of
 from plone.api.validation import mutually_exclusive_parameters
 from plone.api.validation import required_parameters
 
+__all__ = [
+    'add_user',
+    'create',
+    'delete',
+    'get',
+    'get_groups',
+    'get_roles',
+    'grant_roles',
+    'remove_user',
+    'revoke_roles',
+]
 
 @required_parameters('groupname')
 def create(

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -30,6 +30,17 @@ except pkg_resources.DistributionNotFound:
         'set_registry_record will be unavailable.'
     )
 
+__all__ = [
+    'get',
+    'get_localized_time',
+    'get_navigation_root',
+    'get_registry_record',
+    'get_tool',
+    'send_email',
+    'set_registry_record',
+    'show_message',
+]
+
 
 def get():
     """Get the Plone portal object out of thin air.

--- a/src/plone/api/user.py
+++ b/src/plone/api/user.py
@@ -17,6 +17,19 @@ from plone.api.validation import required_parameters
 import random
 import string
 
+__all__ = [
+    'create',
+    'delete',
+    'get',
+    'get_current',
+    'get_permissions',
+    'get_roles',
+    'get_users',
+    'grant_roles',
+    'is_anonymous',
+    'revoke_roles',
+]
+
 
 def create(
     email=None,

--- a/src/plone/api/validation.py
+++ b/src/plone/api/validation.py
@@ -7,6 +7,12 @@ from plone.api.exc import MissingParameterError
 
 import inspect
 
+__all__ = [
+    'at_least_one_of',
+    'mutually_exclusive_parameters',
+    'required_parameters',
+]
+
 
 def _get_arg_spec(func, validator_args):
     """Get the arguments specified in the function spec


### PR DESCRIPTION
This way is easier to find out API methods and functions when using an interactive Python interpreter like IPython or bpython.
