### PR TITLE
Use getUserById to find the user when given a User object in adopt_user.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2.2dev (unreleased)
 ---------------------
 
+- Use getUserById to find the user when given a User object in adopt_user.
+  [tschanzt]
+
 - Made ``api.portal.get_localized_time`` also work with datetime.date
   [nightmarebadger]
 

--- a/src/plone/api/env.py
+++ b/src/plone/api/env.py
@@ -29,15 +29,14 @@ def adopt_user(username=None, user=None):
     :type username: string
     :Example: :ref:`env_adopt_user_example`
     """
-
-    if username is None:
-        username = user.getId()
-
     # Grab the user object out of acl_users because this function
     # accepts 'user' objects that are actually things like MemberData
     # objects, which AccessControl isn't so keen on.
     acl_users = portal.get().acl_users
-    unwrapped = acl_users.getUser(username)
+    if username is None:
+        unwrapped = acl_users.getUserById(user.getId())
+    else:
+        unwrapped = acl_users.getUser(username)
     if unwrapped is None:
         raise UserNotFoundError
 

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -5,7 +5,7 @@ from AccessControl import Unauthorized
 from OFS.SimpleItem import SimpleItem
 from plone import api
 from plone.api.tests.base import INTEGRATION_TESTING
-
+from plone.app.testing import TEST_USER_ID
 import AccessControl
 import AccessControl.SecurityManagement
 import Globals
@@ -414,3 +414,8 @@ class TestPloneApiEnv(unittest.TestCase):
             zope_version(),
             '^(\d+\.\d+|\d+\.\d+\.\d+)(a\d+|b\d+|rc\d+)?$'
         )
+
+    def test_adopt_user_different_username(self):
+        user = api.user.get(userid=TEST_USER_ID)
+        with api.env.adopt_user(user=user):
+            self.assertEqual(api.user.get_current().getId(), TEST_USER_ID)


### PR DESCRIPTION
Currently the adopt_user function assumes when given a user object that the userid and username are the same. But there are several situations where this isn't the case. So I updated the function to use getUserById when given a user.

I use the default plone.app.testing user for testing since his username and userid aren't the same.
