### PR TITLE
grant_roles and revoke_roles errors

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 - Made ``api.portal.get_localized_time`` also work with datetime.date
   [nightmarebadger]
 
+- Raise better/expected errors in ``api.user.grant_roles`` and
+  ``api.user.revoke_roles``
+  [adamcheasley]
+
 1.2.1 (2014-06-24)
 ------------------
 
@@ -241,4 +245,3 @@ Changelog
 - Initial release.
   [davisagli, fulv, iElectric, jcerjak, jonstahl, kcleong, mauritsvanrees,
   wamdam, witsch, zupo]
-

--- a/src/plone/api/tests/test_user.py
+++ b/src/plone/api/tests/test_user.py
@@ -519,6 +519,15 @@ class TestPloneApiUser(unittest.TestCase):
         with self.assertRaises(MissingParameterError):
             api.user.grant_roles()
 
+    def test_grant_roles_no_user(self):
+        """If no user is found, raise a suitable error."""
+        from plone.api.exc import InvalidParameterError
+        with self.assertRaises(InvalidParameterError):
+            api.user.grant_roles(
+                username='chuck',
+                roles=['Manager'],
+            )
+
     def test_revoke_roles(self):
         """Test revoke roles."""
 
@@ -589,6 +598,15 @@ class TestPloneApiUser(unittest.TestCase):
             ROLES,
             set(api.user.get_roles(username='Anonymous User'))
         )
+
+    def test_revoke_roles_no_user(self):
+        """If no user is found, raise a suitable error."""
+        from plone.api.exc import InvalidParameterError
+        with self.assertRaises(InvalidParameterError):
+            api.user.revoke_roles(
+                username='chuck',
+                roles=['Manager'],
+            )
 
     def test_grant_roles_in_context(self):
         """Test grant roles."""

--- a/src/plone/api/user.py
+++ b/src/plone/api/user.py
@@ -310,6 +310,9 @@ def grant_roles(username=None, user=None, obj=None, roles=None):
     """
     if user is None:
         user = get(username=username)
+    # check we got a user
+    if user is None:
+        raise InvalidParameterError("User could not be found")
 
     if isinstance(roles, tuple):
         roles = list(roles)
@@ -350,6 +353,9 @@ def revoke_roles(username=None, user=None, obj=None, roles=None):
     """
     if user is None:
         user = get(username=username)
+    # check we got a user
+    if user is None:
+        raise InvalidParameterError("User could not be found")
 
     if isinstance(roles, tuple):
         roles = list(roles)


### PR DESCRIPTION
Currently, if a user cannot be looked up when calling either gran_roles or revoke_roles then next line that's hit is `user.setSecurityProfile(roles=roles)` if setting global roles. This will mean that the user variable is in fact a NoneType so you will get an AttributeError thrown.
This is a bit unexpected.

This changes checks that the user has been looked up and raises an InvalidParameterError instead.
