### PR TITLE
Add EditorConfig configuration

### DIFF
--- a/docs/contribute/conventions.rst
+++ b/docs/contribute/conventions.rst
@@ -105,6 +105,33 @@ style on ZCML <http://docs.zope.org/zopetoolkit/codingstyle/zcml-style.html>`_
   between attributes and nested elements.
 
 
+EditorConfig
+------------
+
+`EditorConfig <http://editorconfig.org/>`_
+provides a way to share the same configuration for all major source code editors.
+
+You only need to install the plugin for your editor of choice,
+and add the following configuration on ``~/.editorconfig``.
+
+.. sourcecode:: ini
+
+    [*]
+    indent_style = space
+    end_of_line = lf
+    insert_final_newline = true
+    trim_trailing_whitespace = true
+    charset = utf-8
+
+    [*.py]
+    indent_size = 4
+
+    [{*.html,*.dtml,*.pt,*.zpt,*.xml,*.zcml,*.js}]
+    indent_size = 2
+
+    [Makefile]
+    indent_style = tab
+
 Quoting
 =======
 


### PR DESCRIPTION
http://editorconfig.org allows you to have a single source of
configuration for _lots_ of source code editors, which means that,
upon everyone using them, all noise on commits will be gone, as
everyone will be using the same formatting style for files.

That fixes #201.
