### PR TITLE
transition() does _not_ return the new state. 

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -406,7 +406,7 @@ To transition your content to a new workflow state, use the :meth:`api.content.t
 
     from plone import api
     portal = api.portal.get()
-    state = api.content.transition(obj=portal['about'], transition='publish')
+    api.content.transition(obj=portal['about'], transition='publish')
 
 .. invisible-code-block: python
 


### PR DESCRIPTION
The implementation always returns None. So the documentation is wrong here.