### PR TITLE
Make send_email compatible with Plone 5.0b2

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- Make send_email compatible with Plone >= 5.0b2.
+  [pbauer]
+
 - Use the source's parent as a target when no target is specified.
   [jaroel]
 

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -134,8 +134,13 @@ def send_email(sender=None, recipient=None, subject=None, body=None):
     encoding = portal.getProperty('email_charset', 'utf-8')
 
     if not sender:
-        from_address = portal.getProperty('email_from_address', '')
-        from_name = portal.getProperty('email_from_name', '')
+        try:
+            from_address = get_registry_record('plone.email_from_address')
+            from_name = get_registry_record('plone.email_from_name')
+        except InvalidParameterError:
+            # Before Plone 5.0b2 these were stored in portal_properties
+            from_address = portal.getProperty('email_from_address', '')
+            from_name = portal.getProperty('email_from_name', '')
         sender = formataddr((from_name, from_address))
         if parseaddr(sender)[1] != from_address:
             # formataddr probably got confused by special characters.


### PR DESCRIPTION
I'm not 100% sure this is the right approach. In the tests I use the plone-version to determine the way the value is set since the tests will use a released version of Plone. The code itself first checks the registry and falls back to portal_properties since we cannot rely on the version of Plone and CMFPlone being identical.