### PR TITLE
Bring back original convention on sorting imports

### DIFF
--- a/docs/contribute/conventions.rst
+++ b/docs/contribute/conventions.rst
@@ -310,18 +310,15 @@ come last. Again, we *do not* distinguish between what is standard lib,
 external package or internal package in order to save time and avoid the hassle
 of explaining which is which.
 
-As for sorting, it is recommended to use case-sensitive sorting. This means
-uppercase characters come first, so "Products.*" goes before "plone.*".
-
 .. sourcecode:: python
 
     # GOOD
     from __future__ import division
     from Acquisition import aq_inner
-    from Products.CMFCore.interfaces import ISiteRoot
-    from Products.CMFCore.WorkflowCore import WorkflowException
     from plone.api import portal
     from plone.api.exc import MissingParameterError
+    from Products.CMFCore.interfaces import ISiteRoot
+    from Products.CMFCore.WorkflowCore import WorkflowException
 
     import pkg_resources
     import random


### PR DESCRIPTION
This reverts commit 8cfe6da47319ff71725eef2bfab6378ef1280909.

closes #187 