### PR TITLE
Update plone.api.content.get_state docstring. Refs #245

### DIFF
--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -291,7 +291,7 @@ def get_state(obj=None):
     :returns: Object's current workflow state
     :rtype: string
     :raises:
-        ValueError
+        Products.CMFCore.WorkflowCore.WorkflowException
     :Example: :ref:`content_get_state_example`
     """
     workflow = portal.get_tool('portal_workflow')


### PR DESCRIPTION
The underlying workflow engine raises Products.CMFCore.WorkflowCore.WorkflowException
in case when no workflow is associated with the content object (e.g. File or Image).