### PR TITLE
Add an optional 'default' argument to plone.api.content.get_state.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- plone.api.content.get_state now allows for an optional default value.
+  This is used when no workflow is defined for the object. Refs #246
+  [jaroel]
+
 - plone.api.portal.get_registry_record now suggests look-alike records when no records is found. Refs #249.
   [jaroel]
 

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -67,6 +67,7 @@ Consider the following portal structure::
 .. invisible-code-block: python
 
     portal = api.portal.get()
+    image = api.content.create(type='Image', id='image', container=portal)
     blog = api.content.create(type='Link', id='blog', container=portal)
     about = api.content.create(type='Folder', id='about', container=portal)
     events = api.content.create(type='Folder', id='events', container=portal)
@@ -395,6 +396,17 @@ To find out the current workflow state of your content, use the :meth:`api.conte
 
     self.assertEqual(state, 'private')
 
+The optional `default` argument is returned if no workflow is defined for the object.
+
+.. code-block:: python
+
+    from plone import api
+    portal = api.portal.get()
+    state = api.content.get_state(obj=portal['image'], default='Unknown')
+
+.. invisible-code-block: python
+
+    self.assertEqual(state, 'Unknown')
 
 .. _content_transition_example:
 

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -29,6 +29,8 @@ except pkg_resources.DistributionNotFound:
 else:
     from Products.Archetypes.interfaces.base import IBaseObject
 
+_marker = []
+
 
 @required_parameters('container', 'type')
 @at_least_one_of('id', 'title')
@@ -283,19 +285,26 @@ def delete(obj=None, objects=None):
 
 
 @required_parameters('obj')
-def get_state(obj=None):
+def get_state(obj=None, default=_marker):
     """Get the current workflow state of the object.
 
     :param obj: [required] Object that we want to get the state for.
     :type obj: Content object
-    :returns: Object's current workflow state
+    :param default: Returned if no workflow is defined for the object.
+    :returns: Object's current workflow state, or `default`.
     :rtype: string
     :raises:
         Products.CMFCore.WorkflowCore.WorkflowException
     :Example: :ref:`content_get_state_example`
     """
     workflow = portal.get_tool('portal_workflow')
-    return workflow.getInfoFor(obj, 'review_state')
+
+    if default is not _marker and not workflow.getWorkflowsFor(obj):
+        return default
+
+    # This still raises WorkflowException when the workflow state is broken,
+    # ie 'review_state' is absent
+    return workflow.getInfoFor(ob=obj, name='review_state')
 
 
 def _wf_transitions_for(workflow, from_state, to_state):


### PR DESCRIPTION
The default value is returned when there is no workflow defined for the object, so the client code doesn't need to catch WorkflowException.

Closes #246