### PR TITLE
Fix plone.api.content.create in Plone 5.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed plone.api.content.create in Plone 5. Refs 160.
+  [jaroel]
 
 
 1.3.3 (2015-07-14)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module that provides functionality for content manipulation."""
 
-from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.WorkflowCore import WorkflowException
 from copy import copy as _copy
 from plone.api import portal
@@ -81,16 +80,7 @@ def create(
         # so will be swallowed below unless we re-raise it here
         raise
     except ValueError as e:
-        if ISiteRoot.providedBy(container):
-            allowed_types = container.allowedContentTypes()
-            types = [allowed_type.id for allowed_type in allowed_types]
-        else:
-            try:
-                types = container.getLocallyAllowedTypes()
-            except AttributeError:
-                raise InvalidParameterError(
-                    "Cannot add a '%s' object to the container." % type
-                )
+        types = [fti.getId() for fti in container.allowedContentTypes()]
 
         raise InvalidParameterError(
             "Cannot add a '{0}' object to the container.\n"


### PR DESCRIPTION
getLocallyAllowedTypes is no longer available by default. allowedContentTypes is and it does the same thing.

Refs #160