### PR TITLE
Allow plone.api.content.transition to accept kwargs

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -9,7 +9,8 @@ Changelog
   [ale-rt]
 - Fixed plone.api.content.create in Plone 5. Refs 160.
   [jaroel]
-
+- plone.api.content.transition: Now accepts kwargs that can be supplied to the workflow transition.
+  [neilferreira]
 
 1.3.3 (2015-07-14)
 ------------------

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -428,6 +428,15 @@ To transition your content to a new workflow state, use the :meth:`api.content.t
         'published'
     )
 
+If your workflow accepts any additional arguments to the checkin method you may supply them via kwargs.  These arguments can be saved to your transition using custom workflow variables inside of the ZMI using an expression.  ie. "python:state_change.kwargs.get('comment', '')"
+
+.. code-block:: python
+
+    from plone import api
+    portal = api.portal.get()
+    api.content.transition(obj=portal['about'], transition='reject', comment='You had a typo on your page.')
+
+.. invisible-code-block: python
 
 .. _content_get_view_example:
 

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -361,10 +361,12 @@ def _wf_transitions_for(workflow, from_state, to_state):
 @required_parameters('obj')
 @at_least_one_of('transition', 'to_state')
 @mutually_exclusive_parameters('transition', 'to_state')
-def transition(obj=None, transition=None, to_state=None):
+def transition(obj=None, transition=None, to_state=None, **kwargs):
     """Perform a workflow transition for the object or attempt to perform
     workflow transitions on the object to reach the given state.
     The later will not guarantee that transition guards conditions can be met.
+
+    Accepts kwargs to supply to the workflow policy in use, such as "comment"
 
     :param obj: [required] Object for which we want to perform the workflow
         transition.
@@ -381,7 +383,7 @@ def transition(obj=None, transition=None, to_state=None):
     workflow = portal.get_tool('portal_workflow')
     if transition is not None:
         try:
-            workflow.doActionFor(obj, transition)
+            workflow.doActionFor(obj, transition, **kwargs)
         except WorkflowException:
             transitions = [
                 action['id'] for action in workflow.listActions(object=obj)
@@ -411,7 +413,7 @@ def transition(obj=None, transition=None, to_state=None):
                 continue
 
             for transition in transitions:
-                workflow.doActionFor(obj, transition)
+                workflow.doActionFor(obj, transition, **kwargs)
 
             break
 


### PR DESCRIPTION
Will supply to the workflow policy in use for that content item.

See:
https://github.com/do3cc/zope/blob/master/Products.CMFCore/trunk/Products/CMFCore/WorkflowTool.py#L225

Use case: 
formal_workflow has a comments attribute which I would like to populate when transitioning an item to a new state.