### PR TITLE
Add option to skip checking linkintegrity to plone.api.content.delete

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,9 +4,14 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- plone.api.content.delete: add option check_linkintegrity. If True raise
+  exception if deleting would result in broken links.
+  [pbauer]
+
 - plone.api.content.find: object_provides arguments accepts tuples.
   Fixes #266.
   [ale-rt]
+
 - Fixed plone.api.content.create in Plone 5. Refs 160.
   [jaroel]
 

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -358,7 +358,7 @@ To delete multiple content objects, pass the objects to the :meth:`api.content.d
     self.assertFalse(portal.events.get('copy_of_training'))
 
 
-To check if deleting a content object would result in a broken link for another object, set the option `check_linkintegrity` to `True`:
+If deleting content would result in broken links you will get a `LinkIntegrityNotificationException`. To delete anyway, set the option `check_linkintegrity` to `False`:
 
 .. invisible-code-block: python
 
@@ -372,18 +372,12 @@ To check if deleting a content object would result in a broken link for another 
 .. code-block:: python
 
     from plone import api
-    from plone.app.linkintegrity.exceptions import \
-        LinkIntegrityNotificationException
     portal = api.portal.get()
-    try:
-        api.content.delete(
-            obj=portal['copy_of_training'], check_linkintegrity=True)
-    except LinkIntegrityNotificationException:
-        pass
+    api.content.delete(obj=portal['copy_of_training'], check_linkintegrity=False)
 
 .. invisible-code-block: python
 
-    self.assertIn('copy_of_training', portal.keys())
+    self.assertNotIn('copy_of_training', portal.keys())
 
 
 .. _content_manipulation_with_safe_id_option:

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -358,6 +358,34 @@ To delete multiple content objects, pass the objects to the :meth:`api.content.d
     self.assertFalse(portal.events.get('copy_of_training'))
 
 
+To check if deleting a content object would result in a broken link for another object, set the option `check_linkintegrity` to `True`:
+
+.. invisible-code-block: python
+
+    from plone.app.textfield import RichTextValue
+    from zope.lifecycleevent import modified
+    api.content.copy(source=portal['training'], target=portal, safe_id=True)
+    api.content.copy(source=portal['events']['training'], target=portal['events'], safe_id=True)
+    portal['about']['team'].text = RichTextValue('<a href="../copy_of_training">contact</a>')
+    modified(portal['about']['team'])
+
+.. code-block:: python
+
+    from plone import api
+    from plone.app.linkintegrity.exceptions import \
+        LinkIntegrityNotificationException
+    portal = api.portal.get()
+    try:
+        api.content.delete(
+            obj=portal['copy_of_training'], check_linkintegrity=True)
+    except LinkIntegrityNotificationException:
+        pass
+
+.. invisible-code-block: python
+
+    self.assertIn('copy_of_training', portal.keys())
+
+
 .. _content_manipulation_with_safe_id_option:
 
 Content manipulation with the `safe_id` option

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -34,7 +34,7 @@ else:
 
 # Old linkintegrity (Plone <= 5.0b4) or new (Plone > 5.0b4)
 linkintegrity_version = get_distribution('plone.app.linkintegrity').version
-if parse_version(linkintegrity_version) >= parse_version('3.0'):
+if parse_version(linkintegrity_version) >= parse_version('3.0.dev0'):
     NEW_LINKINTEGRITY = True
 else:
     NEW_LINKINTEGRITY = False

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -3,7 +3,9 @@
 
 from Products.CMFCore.WorkflowCore import WorkflowException
 from copy import copy as _copy
+from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
+from pkg_resources import parse_version
 from plone.api import portal
 from plone.api.exc import InvalidParameterError
 from plone.api.validation import at_least_one_of
@@ -19,20 +21,20 @@ from zope.container.interfaces import INameChooser
 from zope.interface import Interface
 from zope.interface import providedBy
 
-import pkg_resources
 import random
 import transaction
 
 try:
-    pkg_resources.get_distribution('Products.Archetypes')
-except pkg_resources.DistributionNotFound:
+    get_distribution('Products.Archetypes')
+except DistributionNotFound:
     class IBaseObject(Interface):
         """Fake Products.Archetypes.interfaces.base.IBaseObject"""
 else:
     from Products.Archetypes.interfaces.base import IBaseObject
 
 # Old linkintegrity (Plone <= 5.0b4) or new (Plone > 5.0b4)
-if get_distribution('plone.app.linkintegrity').version >= 3.0:
+linkintegrity_version = get_distribution('plone.app.linkintegrity').version
+if parse_version(linkintegrity_version) >= parse_version('3.0'):
     NEW_LINKINTEGRITY = True
 else:
     NEW_LINKINTEGRITY = False

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -5,7 +5,6 @@ from Acquisition import aq_base
 from OFS.CopySupport import CopyError
 from OFS.event import ObjectWillBeMovedEvent
 from OFS.interfaces import IObjectWillBeMovedEvent
-from Products.Archetypes.interfaces.base import IBaseContent
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFCore.interfaces import IContentish
 from Products.ZCatalog.interfaces import IZCatalog
@@ -15,6 +14,7 @@ from plone.api.tests.base import INTEGRATION_TESTING
 from plone.app.linkintegrity.exceptions import \
     LinkIntegrityNotificationException
 from plone.app.textfield import RichTextValue
+from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer import indexer
 from plone.uuid.interfaces import IMutableUUID
 from plone.uuid.interfaces import IUUIDGenerator
@@ -697,10 +697,12 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertNotIn('training', self.portal['events'].keys())
 
     def _set_text(self, obj, text):
-        if IBaseContent.providedBy(obj):
-            obj.setText(text, mimetype='text/html')
-        else:
+        if IDexterityContent.providedBy(obj):
+            # Dexterity
             obj.text = RichTextValue(text)
+        else:
+            # Archetypes
+            obj.setText(text, mimetype='text/html')
         modified(obj)
 
     def test_find(self):

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -602,7 +602,7 @@ class TestPloneApiContent(unittest.TestCase):
 
         # Delete the contact page
         api.content.delete(self.contact)
-        assert 'contact' not in container['about'].keys()
+        self.assertNotIn('contact', container['about'].keys())
 
     def test_delete_multiple(self):
         """Test deleting multiple content items."""
@@ -613,36 +613,35 @@ class TestPloneApiContent(unittest.TestCase):
 
         api.content.delete(objects=[container['copy_of_about'],
                                     container['events']['about']])
-        assert 'copy_of_about' not in container
-        assert 'about' not in container['events']
+        self.assertNotIn('copy_of_about', container)
+        self.assertNotIn('about', container['events'])
 
     def test_delete_ignore_linkintegrity(self):
         """Test deleting a content item with a link pointed at it."""
         self._set_text(self.team, '<a href="contact">contact</a>')
         # Delete the contact page
         api.content.delete(self.contact, check_linkintegrity=False)
-        assert 'contact' not in self.portal['about'].keys()
+        self.assertNotIn('contact', self.portal['about'].keys())
 
+    @unittest.skipIf(
+        HAS_PACONTENTYPES and not NEW_LINKINTEGRITY,
+        'This test only makes sense with Archetypes or new Linkintegrity.')
     def test_delete_check_linkintegrity(self):
         """Test deleting a content item with a link pointed at it."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
         self._set_text(self.team, '<a href="contact">contact</a>')
         # Delete the contact page
         with self.assertRaises(LinkIntegrityNotificationException):
             api.content.delete(self.contact)
-        assert 'contact' in self.portal['about'].keys()
         if NEW_LINKINTEGRITY:
             # In the old implementation of linkintegrity the items are
             # still gone during this request.
             self.assertIn('contact', self.portal['about'].keys())
 
+    @unittest.skipIf(
+        HAS_PACONTENTYPES and not NEW_LINKINTEGRITY,
+        'This test only makes sense with Archetypes or new Linkintegrity.')
     def test_delete_multiple_check_linkintegrity(self):
         """Test deleting multiple item with linkintegrity-breaches."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
         self._set_text(self.team, '<a href="../about/contact">contact</a>')
         self._set_text(self.training, '<a href="../blog">contact</a>')
         # Delete the contact page
@@ -654,11 +653,11 @@ class TestPloneApiContent(unittest.TestCase):
             self.assertIn('contact', self.portal['about'].keys())
             self.assertIn('blog', self.portal.keys())
 
+    @unittest.skipIf(
+        HAS_PACONTENTYPES and not NEW_LINKINTEGRITY,
+        'This test only makes sense with Archetypes or new Linkintegrity.')
     def test_delete_multiple_ignore_linkintegrity(self):
         """Test deleting multiple items ignoring linkintegrity-breaches."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
         self._set_text(self.team, '<a href="../about/contact">contact</a>')
         self._set_text(self.training, '<a href="../blog">contact</a>')
         # Delete linked pages
@@ -668,16 +667,29 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertNotIn('contact', self.portal['about'].keys())
         self.assertNotIn('blog', self.portal.keys())
 
+    @unittest.skipIf(
+        HAS_PACONTENTYPES and not NEW_LINKINTEGRITY,
+        'This test only makes sense with Archetypes or new Linkintegrity.')
     def test_delete_with_internal_breaches(self):
         """Test deleting multiple with internal linkintegrity breaches."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
         self._set_text(self.team, '<a href="../about/contact">contact</a>')
         self._set_text(self.training, '<a href="../blog">contact</a>')
         # Deleting pages with unresolved breaches throws an exception
         with self.assertRaises(LinkIntegrityNotificationException):
             api.content.delete(objects=[self.blog, self.about])
+        if NEW_LINKINTEGRITY:
+            # In the old implementation of linkintegrity the items are
+            # still gone during this request.
+            self.assertIn('about', self.portal.keys())
+            self.assertIn('blog', self.portal.keys())
+            self.assertIn('training', self.portal['events'].keys())
+
+    @unittest.skipUnless(
+        NEW_LINKINTEGRITY, 'Only new Linkintegrity resolves internal breaches')
+    def test_delete_with_resolved_internal_breaches(self):
+        """Test deleting multiple with internal linkintegrity breaches."""
+        self._set_text(self.team, '<a href="../about/contact">contact</a>')
+        self._set_text(self.training, '<a href="../blog">contact</a>')
         # Deleting pages with resolved breaches throws no exception
         api.content.delete(objects=[self.blog, self.training, self.about])
         self.assertNotIn('about', self.portal.keys())

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -624,7 +624,8 @@ class TestPloneApiContent(unittest.TestCase):
         api.content.delete(self.contact, check_linkintegrity=False)
         assert 'contact' not in container['about'].keys()
 
-    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
+    @unittest.skipUnless(
+        NEW_LINKINTEGRITY, 'Test fails with old linkintegrity')
     def test_delete_check_linkintegrity(self):
         """Test deleting a content item with a link pointed at it."""
         self.team.text = RichTextValue('<a href="contact">contact</a>')
@@ -635,7 +636,8 @@ class TestPloneApiContent(unittest.TestCase):
             api.content.delete(self.contact)
         assert 'contact' in container['about'].keys()
 
-    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
+    @unittest.skipUnless(
+        NEW_LINKINTEGRITY, 'Test fails with old linkintegrity')
     def test_delete_multiple_check_linkintegrity(self):
         """Test deleting multiple item with linkintegrity-breaches."""
         self.team.text = RichTextValue(
@@ -651,7 +653,8 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertIn('contact', container['about'].keys())
         self.assertIn('blog', container.keys())
 
-    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
+    @unittest.skipUnless(
+        NEW_LINKINTEGRITY, 'Test fails with old linkintegrity')
     def test_delete_multiple_ignore_linkintegrity(self):
         """Test deleting multiple items ignoring linkintegrity-breaches."""
         from plone.app.linkintegrity.utils import hasOutgoingLinks
@@ -675,7 +678,8 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertFalse(hasOutgoingLinks(self.team))
         self.assertFalse(hasOutgoingLinks(self.training))
 
-    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
+    @unittest.skipUnless(
+        NEW_LINKINTEGRITY, 'Test fails with old linkintegrity')
     def test_delete_with_internal_breaches(self):
         """Test deleting multiple with internal linkintegrity breaches."""
         from plone.app.linkintegrity.utils import hasIncomingLinks

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -620,7 +620,7 @@ class TestPloneApiContent(unittest.TestCase):
         modified(self.team)
         container = self.portal
         # Delete the contact page
-        api.content.delete(self.contact)
+        api.content.delete(self.contact, check_linkintegrity=False)
         assert 'contact' not in container['about'].keys()
 
     def test_delete_check_linkintegrity(self):
@@ -630,7 +630,7 @@ class TestPloneApiContent(unittest.TestCase):
         container = self.portal
         # Delete the contact page
         with self.assertRaises(LinkIntegrityNotificationException):
-            api.content.delete(self.contact, check_linkintegrity=True)
+            api.content.delete(self.contact)
         assert 'contact' in container['about'].keys()
 
     def test_delete_multiple_check_linkintegrity(self):
@@ -644,9 +644,7 @@ class TestPloneApiContent(unittest.TestCase):
         container = self.portal
         # Delete the contact page
         with self.assertRaises(LinkIntegrityNotificationException):
-            api.content.delete(
-                objects=[self.blog, self.contact],
-                check_linkintegrity=True)
+            api.content.delete(objects=[self.blog, self.contact])
         self.assertIn('contact', container['about'].keys())
         self.assertIn('blog', container.keys())
 
@@ -664,7 +662,9 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertTrue(hasIncomingLinks(self.contact))
         container = self.portal
         # Delete linked pages
-        api.content.delete(objects=[self.blog, self.contact])
+        api.content.delete(
+            objects=[self.blog, self.contact],
+            check_linkintegrity=False)
         self.assertNotIn('contact', container['about'].keys())
         self.assertNotIn('blog', container.keys())
         # Linkintegrity-relations are removed and objects have broken links
@@ -685,13 +685,9 @@ class TestPloneApiContent(unittest.TestCase):
         container = self.portal
         # Deleting pages with unresolved breaches throws an exception
         with self.assertRaises(LinkIntegrityNotificationException):
-            api.content.delete(
-                objects=[self.blog, self.about],
-                check_linkintegrity=True)
+            api.content.delete(objects=[self.blog, self.about])
         # Deleting pages with resolved breaches throws no exception
-        api.content.delete(
-            objects=[self.blog, self.training, self.about],
-            check_linkintegrity=True)
+        api.content.delete(objects=[self.blog, self.training, self.about])
         self.assertNotIn('about', container.keys())
         self.assertNotIn('blog', container.keys())
         self.assertNotIn('training', container['events'].keys())

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -12,6 +12,7 @@ from plone import api
 from plone.api.tests.base import INTEGRATION_TESTING
 from plone.app.linkintegrity.exceptions import \
     LinkIntegrityNotificationException
+from plone.api.content import NEW_LINKINTEGRITY
 from plone.app.textfield import RichTextValue
 from plone.indexer import indexer
 from plone.uuid.interfaces import IMutableUUID
@@ -623,6 +624,7 @@ class TestPloneApiContent(unittest.TestCase):
         api.content.delete(self.contact, check_linkintegrity=False)
         assert 'contact' not in container['about'].keys()
 
+    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
     def test_delete_check_linkintegrity(self):
         """Test deleting a content item with a link pointed at it."""
         self.team.text = RichTextValue('<a href="contact">contact</a>')
@@ -633,6 +635,7 @@ class TestPloneApiContent(unittest.TestCase):
             api.content.delete(self.contact)
         assert 'contact' in container['about'].keys()
 
+    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
     def test_delete_multiple_check_linkintegrity(self):
         """Test deleting multiple item with linkintegrity-breaches."""
         self.team.text = RichTextValue(
@@ -648,6 +651,7 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertIn('contact', container['about'].keys())
         self.assertIn('blog', container.keys())
 
+    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
     def test_delete_multiple_ignore_linkintegrity(self):
         """Test deleting multiple items ignoring linkintegrity-breaches."""
         from plone.app.linkintegrity.utils import hasOutgoingLinks
@@ -671,6 +675,7 @@ class TestPloneApiContent(unittest.TestCase):
         self.assertFalse(hasOutgoingLinks(self.team))
         self.assertFalse(hasOutgoingLinks(self.training))
 
+    @unittest.skipUnless(NEW_LINKINTEGRITY, 'Test fails with old linintegrity')
     def test_delete_with_internal_breaches(self):
         """Test deleting multiple with internal linkintegrity breaches."""
         from plone.app.linkintegrity.utils import hasIncomingLinks

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -633,43 +633,24 @@ class TestPloneApiContent(unittest.TestCase):
         with self.assertRaises(LinkIntegrityNotificationException):
             api.content.delete(self.contact)
         assert 'contact' in self.portal['about'].keys()
-
-    def test_delete_check_linkintegrity_archetypes(self):
-        """Test deleting archetypes content with a link pointed at it."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
-        self._set_text(self.team, '<a href="contact">contact</a>')
-        self.assertIn('contact', self.portal['about'].keys())
-        # Delete the contact page
-        api.content.delete(self.contact)
-        with self.assertRaises(LinkIntegrityNotificationException):
-            api.content.delete(self.contact)
         if NEW_LINKINTEGRITY:
-            # In the old implementation the items are still during this
-            # request.
+            # In the old implementation of linkintegrity the items are
+            # still gone during this request.
             self.assertIn('contact', self.portal['about'].keys())
-
-    def test_delete_ignore_linkintegrity_archetypes(self):
-        """Test deleting archetypes content with a link pointed at it."""
-        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
-            # This test only makes sense with Archetypes or new Linkintegrity
-            return
-        self._set_text(self.team, '<a href="contact">contact</a>')
-        # Delete the contact page
-        api.content.delete(self.contact, check_linkintegrity=False)
-        self.assertNotIn('contact', self.portal['about'].keys())
 
     def test_delete_multiple_check_linkintegrity(self):
         """Test deleting multiple item with linkintegrity-breaches."""
+        if not IBaseContent.providedBy(self.team) or not NEW_LINKINTEGRITY:
+            # This test only makes sense with Archetypes or new Linkintegrity
+            return
         self._set_text(self.team, '<a href="../about/contact">contact</a>')
         self._set_text(self.training, '<a href="../blog">contact</a>')
         # Delete the contact page
         with self.assertRaises(LinkIntegrityNotificationException):
             api.content.delete(objects=[self.blog, self.contact])
         if NEW_LINKINTEGRITY:
-            # In the old implementation the items are still during this
-            # request.
+            # In the old implementation of linkintegrity the items are
+            # still gone during this request.
             self.assertIn('contact', self.portal['about'].keys())
             self.assertIn('blog', self.portal.keys())
 


### PR DESCRIPTION
Please review (works only with https://github.com/plone/plone.app.linkintegrity/pull/23). 

The main questions:
- Is it ok that the default for ``check_linkintegrity`` is ``False`` 
- Is raising the exception ``plone.app.linkintegrity.exceptions.LinkIntegrityNotificationException`` the right way to deal with breaches?
- It only works in Plone 5 (current coredev).
