### PR TITLE
Fix content.find with both path and depth

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.4.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed `api.content.find` with combination of depth and path.  Path
+  is no longer ignored then.
+  [maurits]
 
 
 1.4.5 (2015-09-09)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -572,9 +572,11 @@ def find(context=None, depth=None, **kwargs):
     Specifing the search depth is supported using the `depth` argument.
     >>> find(depth=1)
 
-    Using `depth` needs a context for it's path. If no context is passed, the
-    portal root is used.
+    Using `depth` needs a context for it's path. If no context and no
+    path is passed, the portal root is used.
     >>> find(context=portal, depth=1, portal_type='Document')
+    - or -
+    >>> find(depth=1, path='/plone/folder', portal_type='Document')
     - or -
     >>> find(depth=1, portal_type='Document')
 
@@ -595,14 +597,19 @@ def find(context=None, depth=None, **kwargs):
     query.update(**kwargs)
 
     # Passing a context or depth overrides the existing path query
-    if context or depth:
+    # Save the original path to maybe restore it.
+    orig_path = query.get('path')
+    if context or depth is not None:
         query['path'] = {}
 
     # Limit search depth
     if depth is not None:
         # If we don't have a context, we'll assume the portal root.
-        if context is None:
+        if context is None and not orig_path:
             context = portal.get()
+        else:
+            # Restore the original path
+            query['path']['query'] = orig_path
         query['path']['depth'] = depth
 
     if context is not None:

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -596,11 +596,17 @@ def find(context=None, depth=None, **kwargs):
     query = {}
     query.update(**kwargs)
 
-    # Passing a context or depth overrides the existing path query
-    # Save the original path to maybe restore it.
+    # Save the original path to maybe restore it later.
     orig_path = query.get('path')
+    if isinstance(orig_path, dict):
+        orig_path = orig_path.get('query')
+
+    # Passing a context or depth overrides the existing path query,
+    # for now.
     if context or depth is not None:
-        query['path'] = {}
+        # Make the path a dictionary, unless it already is.
+        if not isinstance(orig_path, dict):
+            query['path'] = {}
 
     # Limit search depth
     if depth is not None:

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -754,6 +754,20 @@ class TestPloneApiContent(unittest.TestCase):
             context=self.portal.about, depth=0, portal_type='Document')
         self.assertEqual(len(documents), 0)
 
+        # Limit search depth with explicit path
+        documents = api.content.find(
+            path='/'.join(self.portal.about.getPhysicalPath()),
+            depth=1, portal_type='Document')
+        self.assertEqual(len(documents), 2)
+        documents = api.content.find(
+            path='/'.join(self.portal.about.getPhysicalPath()),
+            depth=0, portal_type='Document')
+        self.assertEqual(len(documents), 0)
+        documents = api.content.find(
+            path='/'.join(self.portal.events.getPhysicalPath()),
+            depth=1, portal_type='Document')
+        self.assertEqual(len(documents), 0)
+
     def test_find_interface(self):
         # Find documents by interface or it's identifier
         identifier = IContentish.__identifier__

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -797,6 +797,24 @@ class TestPloneApiContent(unittest.TestCase):
         documents = api.content.find(**query)
         self.assertEqual(len(documents), 0)
 
+        # This is a bit awkward, but it is nice if this does not crash.
+        query = {
+            'depth': 2,
+            'portal_type': 'Document',
+            'path': {'query': path}
+            }
+        documents = api.content.find(**query)
+        self.assertEqual(len(documents), 2)
+
+        path = '/'.join(self.portal.events.getPhysicalPath())
+        query = {
+            'depth': 2,
+            'portal_type': 'Document',
+            'path': {'query': path}
+            }
+        documents = api.content.find(**query)
+        self.assertEqual(len(documents), 0)
+
     def test_get_state(self):
         """Test retrieving the workflow state of a content item."""
 


### PR DESCRIPTION
If you specify a depth and a path, until now we ignored the path. Not nice.

I discovered this while developing on a client project. I did `content.find(path='/plone/folder', depth=1)` and it returned all items in the Plone site root instead of in `/plone/folder`.

The alternative is to do `content.find({'path': {'query': '/plone/folder', 'depth': 1}})`, but I have always find this ugly.