### PR TITLE
No need for unittest2

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
   is no longer ignored then.
   [maurits]
 
+- Remove unittest2 dependency.
+  [gforcada]
+
 
 1.4.5 (2015-09-09)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
             'plone.app.testing',
             'plone.indexer',
             'plone.registry',
-            'unittest2',
         ],
         'archetypes': [
             'Products.Archetypes',

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -29,7 +29,7 @@ from zope.lifecycleevent import modified
 
 import mock
 import pkg_resources
-import unittest2 as unittest
+import unittest
 
 try:
     pkg_resources.get_distribution('plone.app.contenttypes')

--- a/src/plone/api/tests/test_doctests.py
+++ b/src/plone/api/tests/test_doctests.py
@@ -19,7 +19,7 @@ import manuel.testing
 import os
 import re
 import transaction
-import unittest2 as unittest
+import unittest
 
 try:
     pkg_resources.get_distribution('plone.app.contenttypes')

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -9,7 +9,7 @@ from plone.app.testing import TEST_USER_ID
 import AccessControl
 import AccessControl.SecurityManagement
 import Globals
-import unittest2 as unittest
+import unittest
 
 
 class ExampleException(Exception):

--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -6,7 +6,7 @@ from plone import api
 from plone.api.tests.base import INTEGRATION_TESTING
 
 import mock
-import unittest2 as unittest
+import unittest
 
 
 class TestPloneApiGroup(unittest.TestCase):

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -21,7 +21,7 @@ from zope.component.hooks import setSite
 from zope.site import LocalSiteManager
 
 import mock
-import unittest2 as unittest
+import unittest
 
 HAS_PLONE5 = env.plone_version() >= '5.0b2'
 

--- a/src/plone/api/tests/test_user.py
+++ b/src/plone/api/tests/test_user.py
@@ -9,7 +9,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_ID
 
 import mock
-import unittest2 as unittest
+import unittest
 
 
 class TestPloneApiUser(unittest.TestCase):

--- a/src/plone/api/tests/test_validation.py
+++ b/src/plone/api/tests/test_validation.py
@@ -7,7 +7,7 @@ from plone.api.validation import at_least_one_of
 from plone.api.validation import mutually_exclusive_parameters
 from plone.api.validation import required_parameters
 
-import unittest2 as unittest
+import unittest
 
 
 def undecorated_func(arg1=None, arg2=None, arg3=None):


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.