### PR TITLE
WIP Update docstring on send_email

### DIFF
--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -129,7 +129,7 @@ def send_email(sender=None, recipient=None, subject=None, body=None,
     :param subject: [required] Subject of the email.
     :type subject: string
     :param body: [required] Body text of the email
-    :type body: string
+    :type body: string or python's email object
     :param immediate: Send immediate or queued at transaction commit time. When
         sending immediate the mail might get sent out multiple time in case of
         transaction aborts and retries.


### PR DESCRIPTION
Although a string is expected (and only if it's unicode is encoded),
passing a python's email object works as well.

This avoids having to change send_email signature to support every field that could be used on an email,
like attachments, reply_to, CC, etc etc