### PR TITLE
Corner case: only exit transitions

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -25,6 +25,10 @@ Fixes:
 - Cleanup code to match Plone's style guide.
   [gforcada]
 
+- Fix corner case on content.transition code: if a transition only has
+  exit transitions and no transition goes back to it ``find_path`` will fail.
+  [gforcada]
+
 1.4.11 (2016-01-08)
 -------------------
 

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -392,6 +392,10 @@ def _wf_transitions_for(workflow, from_state, to_state):
     # work backwards from our end state
     def find_path(maps, path, current_state, start_state):
         paths = []
+        # current_state could not be on maps if it only has outgoing
+        # transitions. i.e an initial state you are not able to return to.
+        if current_state not in maps:
+            return
         for new_transition, from_states in maps[current_state]:
             next_path = _copy(path)
             if new_transition in path:


### PR DESCRIPTION
If a workflow has a state where no transition goes back to it,
an initial state has to be,
then without this check the line below this patch fails as the
state id is not found on the dictionary.

Should I add a test for it? Looking at the current tests it seems that it would be too much for such a small change.