### PR TITLE
Handle automatic transitions

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -29,6 +29,9 @@ Fixes:
   exit transitions and no transition goes back to it ``find_path`` will fail.
   [gforcada]
 
+- Handle automatic transitions on api.content.transition.
+  [gforcada]
+
 1.4.11 (2016-01-08)
 -------------------
 

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -477,7 +477,14 @@ def transition(obj=None, transition=None, to_state=None, **kwargs):
                 continue
 
             for transition in transitions:
-                workflow.doActionFor(obj, transition, **kwargs)
+                try:
+                    workflow.doActionFor(obj, transition, **kwargs)
+                except WorkflowException:
+                    # take into account automatic transitions.
+                    # If the transitions list that are being iterated over
+                    # have automatic transitions they need to be skipped
+                    if get_state(obj) == to_state:
+                        break
 
             break
 


### PR DESCRIPTION
If content.transition is called with a to_state parameter,
a list of transitions that make possible to move from the object original
state to the final desired state is compiled with ``_wf_transitions_for``.

If that list of transitions contain any automatic transition and is triggered
the iteration over that list of transitions will be broken as the
automatic transition will have already happened.

This commit handles this case.

Again, just like #306 making a test for this seems not trivial at all :-/

Is there a way to create workflows on the fly easily?