### PR TITLE
Fix an AttributeError in `api.user.revoke_roles`

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 ------------------
 
 Fixes:
+- Fix an AttributeError in `api.user.revoke_roles`
+  [ale-rt]
 
 - Typo in the documentation.
   [ale-rt]

--- a/src/plone/api/user.py
+++ b/src/plone/api/user.py
@@ -408,7 +408,8 @@ def revoke_roles(username=None, user=None, obj=None, roles=None):
     if obj is not None:
         # if obj, get only a list of local roles, without inherited ones
         inherit = False
-    actual_roles = get_roles(user=user, obj=obj, inherit=inherit)
+
+    actual_roles = list(get_roles(user=user, obj=obj, inherit=inherit))
     if actual_roles.count('Anonymous'):
         actual_roles.remove('Anonymous')
     if actual_roles.count('Authenticated'):


### PR DESCRIPTION
`actual_roles` should be a list, but the `get_roles` function might return a tuple.
If that happens you will have an attribute error when calling `actual_roles.remove`.

`get_roles` returns a tuple when it passes here:

- https://github.com/plone/plone.api/blob/3af258a0317d17ed251cb4658f0b034b2e205b3c/src/plone/api/user.py#L243

given that the function `get_local_roles_for_userid` from `AccessControl` always returns a tuple:

- https://github.com/zopefoundation/AccessControl/blob/501afff5636bc6d695b8a2a75e4ff93d3affcac4/src/AccessControl/rolemanager.py#L327