### PR TITLE
Allow adopting to a Special User

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 ------------------
 
 Fixes:
+- Allow adopting to a Special User. Fixes #320 - checking permissions for Anonymous User.
+  [jaroel]
+
 - Fix an AttributeError in `api.user.revoke_roles`
   [ale-rt]
 

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -370,6 +370,10 @@ class TestPloneApiEnv(unittest.TestCase):
         api.env.adopt_user(username='admin')
         api.env.adopt_user(user=api.user.get(username='admin'))
 
+    def test_adopting_anonymous(self):
+        from AccessControl import users
+        api.env.adopt_user(user=users.nobody)
+
     def test_empty_warning(self):
         """Tests that empty roles lists get warned about."""
         from plone.api.exc import InvalidParameterError

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -371,8 +371,10 @@ class TestPloneApiEnv(unittest.TestCase):
         api.env.adopt_user(user=api.user.get(username='admin'))
 
     def test_adopting_anonymous(self):
-        from AccessControl import users
-        api.env.adopt_user(user=users.nobody)
+        from AccessControl.users import nobody
+        self.assertNotEqual(nobody, api.user.get_current())
+        with api.env.adopt_user(user=nobody):
+            self.assertEqual(nobody, api.user.get_current())
 
     def test_empty_warning(self):
         """Tests that empty roles lists get warned about."""


### PR DESCRIPTION
Allow adopting to a Special User, which in turn makes it possible to check for permissions of an Anonymous User.
Fixes #320.
