### PR TITLE
Avoid a copy & paste on api.conent.move

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -25,6 +25,9 @@ Fixes:
 - Fix travis and coveralls.
   [gforcada]
 
+- In api.content.move if source **and** target are specified and target is already
+  source parent, skip the operation.
+
 1.5 (2016-02-20)
 ----------------
 

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -185,9 +185,10 @@ def move(source=None, target=None, id=None, safe_id=False):
     source_id = source.getId()
 
     # If no target is given the object is probably renamed
-    if target:
-        target.manage_pasteObjects(
-            source.aq_parent.manage_cutObjects(source_id))
+    if target and source.aq_parent is not target:
+            target.manage_pasteObjects(
+                source.aq_parent.manage_cutObjects(source_id)
+            )
     else:
         target = source.aq_parent
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -403,11 +403,15 @@ class TestPloneApiContent(unittest.TestCase):
 
     def test_move_no_move_if_target_is_source_parent(self):
         """Test that trying to move an object to its parent is a noop"""
-        new_contact = api.content.move(
-            source=self.contact,
-            target=self.contact.aq_parent,
-        )
-        assert new_contact == self.contact
+
+        target = self.contact.aq_parent
+        with mock.patch.object(target, 'manage_pasteObjects'):
+            api.content.move(
+                source=self.contact,
+                target=target,
+            )
+
+            self.assertFalse(target.manage_pasteObjects.called)
 
     def test_rename_constraints(self):
         """Test the constraints for rename content."""

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -401,6 +401,14 @@ class TestPloneApiContent(unittest.TestCase):
         assert (container['events']['about'] and
                 container['events']['about'] == about)
 
+    def test_move_no_move_if_target_is_source_parent(self):
+        """Test that trying to move an object to its parent is a noop"""
+        new_contact = api.content.move(
+            source=self.contact,
+            target=self.contact.aq_parent,
+        )
+        assert new_contact == self.contact
+
     def test_rename_constraints(self):
         """Test the constraints for rename content."""
         from plone.api.exc import MissingParameterError


### PR DESCRIPTION
If source parent's is the target.

Fixes
https://github.com/plone/plone.api/issues/313