### PR TITLE
Fix translation related tests to use the ``plonelocales`` domain instead `…

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 Fixes:
 
+- Fix translation related tests to use the ``plonelocales`` domain instead ``passwordresettool``.
+  Products.PasswordResetTool was removed in Plone 5.1.
+  [thet]
+
 - Allow plone.api.group.get_groups for Anonymous user. Refs #290
   [jaroel]
 

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -810,8 +810,8 @@ class TestPloneApiPortal(unittest.TestCase):
         )
         self.assertEqual(
             portal.translate(
-                'Set my password',
-                domain='passwordresettool',
+                'month_apr',
+                domain='plonelocales',
                 lang='fr'),
-            u'Définir mon mot de passe'
+            u'Avril'
         )


### PR DESCRIPTION
…`passwordresettool``.

Products.PasswordResetTool was removed in Plone 5.1.