### PR TITLE
Remove getIcon usage

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -32,6 +32,9 @@ Fixes:
 - In api.content.move if source **and** target are specified and target is already
   source parent, skip the operation.
 
+- Fix test
+  [gforcada]
+
 1.5 (2016-02-20)
 ----------------
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -964,7 +964,7 @@ class TestPloneApiContent(unittest.TestCase):
         )
         self.assertEqual(aq_base(view.context), aq_base(self.blog))
         self.assertEqual(view.__name__, 'plone')
-        self.assertTrue(hasattr(view, 'getIcon'))
+        self.assertTrue(hasattr(view, 'toLocalizedTime'))
 
         # Try another standard view.
         view = api.content.get_view(


### PR DESCRIPTION
It was already deprecated and finally it has been removed.

To be merged with:
https://github.com/plone/plone.app.layout/pull/104
https://github.com/plone/Products.CMFPlone/pull/1838