### PR TITLE
Fix PRINTINGMAILHOST_ENABLED evaluation

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -43,6 +43,10 @@ Fixes:
 - Fix test
   [gforcada]
 
+- Fix PRINTINGMAILHOST_ENABLED evaluation to respect Products.PrintingMailHost
+  internal logic
+  [ale-rt]
+
 1.5 (2016-02-20)
 ----------------
 

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -35,15 +35,24 @@ except pkg_resources.DistributionNotFound:
     )
 
 try:
-    pkg_resources.get_distribution('Products.PrintingMailHost')
-except pkg_resources.DistributionNotFound:
+    from Products import PrintingMailHost
+except ImportError:
+    PrintingMailHost = None
+
+if not PrintingMailHost:
     PRINTINGMAILHOST_ENABLED = False
+elif (
+    PrintingMailHost.ENABLED is not None and
+    PrintingMailHost.ENABLED.lower() in PrintingMailHost.TRUISMS
+):
+    PRINTINGMAILHOST_ENABLED = True
+elif (
+    PrintingMailHost.ENABLED is None and
+    PrintingMailHost.DevelopmentMode is True
+):
+    PRINTINGMAILHOST_ENABLED = True
 else:
-    # PrintingMailHost only patches in debug mode.
-    # plone.api.env.debug_mode cannot be used here, because .env imports this
-    # file
-    import Globals
-    PRINTINGMAILHOST_ENABLED = Globals.DevelopmentMode
+    PRINTINGMAILHOST_ENABLED = False
 
 MISSING = object()
 


### PR DESCRIPTION
Since 2009 PrintingMailhost works also in background mode if the environment variable `ENABLE_PRINTING_MAILHOST` is set to a truish value.

This patch will make `plone.api` respect the this feature.

See the commit that introduced this feature:

- https://github.com/collective/Products.PrintingMailHost/commit/8304005dc1ab0269d2c5d511f7dfe384bc5caeaf#diff-9f3a143adef80d3e78527c8903db7db3L3