### PR TITLE
Fix env tests in Zope4

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -20,6 +20,9 @@ Bug fixes:
 - Fix imports from Globals that was removed in Zope4
   [pbauer]
 
+- Fix error in tests that try to add built-in roles, which no longer fails
+  silently in Zope4.
+  [MatthewWilkes]
 
 1.5.1 (2016-12-06)
 ------------------

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -70,8 +70,8 @@ class TestPloneApiEnv(unittest.TestCase):
 
         # Roles need to be created by name before we can assign permissions
         # to them or grant them to users.
-        for role in ('Member', 'VIP', 'Manager'):
-            portal._addRole(role)
+        # 'Member' and 'Manager' already exist by default, we need to add 'VIP'
+        portal._addRole('VIP')
 
         for permission, roles in role_mapping:
             portal.manage_permission(permission, roles, 1)


### PR DESCRIPTION
No longer try to add Member and Manager roles in role tests, as in Zope4 adding a duplicate role raises an exception.