### PR TITLE
Raise InvalidParameterError on duplicate id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Simplify the ``plone.api.content.delete`` method.
   [thet]
 
+- content.copy with safe_id=False should raise it's own exeception. Fixes #340
+  [jaroel]
+
 
 1.6.1 (2017-03-31)
 ------------------

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -262,7 +262,8 @@ def copy(source=None, target=None, id=None, safe_id=False):
     new_id = copy_info[0]['new_id']
     if id:
         if not safe_id and id in target:
-            raise InvalidParameterError
+            msg = "Duplicate ID '{0}' in '{1}' for '{2}'"
+            raise InvalidParameterError(msg.format(id, target, source))
         else:
             return rename(obj=target[new_id], new_id=id, safe_id=safe_id)
     else:

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -261,7 +261,10 @@ def copy(source=None, target=None, id=None, safe_id=False):
 
     new_id = copy_info[0]['new_id']
     if id:
-        return rename(obj=target[new_id], new_id=id, safe_id=safe_id)
+        if not safe_id and id in target:
+            raise InvalidParameterError
+        else:
+            return rename(obj=target[new_id], new_id=id, safe_id=safe_id)
     else:
         return target[new_id]
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -594,6 +594,17 @@ class TestPloneApiContent(unittest.TestCase):
         assert container['bargains']['item'].aq_base is bargain.aq_base
         assert container['products']['item']
 
+    def test_copy_same_id(self):
+        obj = self.contact
+
+        # Using the same id should fail
+        from plone.api.exc import InvalidParameterError
+        with self.assertRaises(InvalidParameterError):
+            api.content.copy(obj, obj.__parent__, obj.id)
+
+        # Using safe_id=True should work
+        api.content.copy(obj, obj.__parent__, obj.id, safe_id=True)
+
     def test_delete_constraints(self):
         """Test the constraints for deleting content."""
 


### PR DESCRIPTION
but not when safe_id=True.
Fixes #340 