### PR TITLE
Let zope.i18n do language negotiation for our translate function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Let ``zope.i18n`` do the language negotiation for our ``translate`` function.
+  Our ``get_current_translation`` does not always give the correct one, especially with combined languages:
+  ``nl-be`` (Belgian/Flemish) should fall back to ``nl`` (Dutch).
+  The correct negotiated language can also differ per translation domain, which we do not account for.
+  ``zope.i18n`` does that better.
+  Fixes `issue 379 <https://github.com/plone/plone.api/issues/379>`_.
+  [maurits]
 
 
 1.8 (2017-08-05)

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -445,11 +445,12 @@ def translate(msgid, domain='plone', lang=None):
     :Example: :ref:`portal_translate_example`
     """
     translation_service = get_tool('translation_service')
-    if not lang:
-        lang = get_current_language()
-
-    return translation_service.utranslate(
-        msgid=msgid,
-        domain=domain,
-        target_language=lang,
-    )
+    query = {
+        'msgid': msgid,
+        'domain': domain,
+        'target_language': lang,
+    }
+    if lang is None:
+        # Pass the request, so zope.i18n.translate can negotiate the language.
+        query['context'] = getRequest()
+    return translation_service.utranslate(**query)


### PR DESCRIPTION
Our ``get_current_translation`` does not always give the correct one, especially with combined languages:
``nl-be`` (Belgian/Flemish) should fall back to ``nl`` (Dutch). ``zope.i18n`` does that correctly.

The correct negotiated language can also [differ per translation domain](https://github.com/zopefoundation/zope.i18n/blob/4.2.0/src/zope/i18n/translationdomain.py#L78-L83), which we do not account for.

I tried adding tests, but I could not get them to work and test anything useful.

Fixes #379.