### PR TITLE
Don't rename an object when the id already is the target id.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Don't rename an object when the id already is the target id. Refs #361.
+  [jaroel]
+
 - Let ``zope.i18n`` do the language negotiation for our ``translate`` function.
   Our ``get_current_translation`` does not always give the correct one, especially with combined languages:
   ``nl-be`` (Belgian/Flemish) should fall back to ``nl`` (Dutch).

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -193,9 +193,9 @@ def move(source=None, target=None, id=None, safe_id=False):
 
     # If no target is given the object is probably renamed
     if target and source.aq_parent is not target:
-            target.manage_pasteObjects(
-                source.aq_parent.manage_cutObjects(source_id),
-            )
+        target.manage_pasteObjects(
+            source.aq_parent.manage_cutObjects(source_id),
+        )
     else:
         target = source.aq_parent
 
@@ -227,7 +227,8 @@ def rename(obj=None, new_id=None, safe_id=False):
         chooser = INameChooser(container)
         new_id = chooser.chooseName(new_id, obj)
 
-    container.manage_renameObject(obj_id, new_id)
+    if obj_id != new_id:
+        container.manage_renameObject(obj_id, new_id)
     return container[new_id]
 
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -550,6 +550,9 @@ class TestPloneApiContent(unittest.TestCase):
                 container['about']['link-to-blog-1-1'] == linktoblog11)
         assert 'link-to-blog' not in container.keys()
 
+    def test_rename_same_id(self):
+        api.content.rename(obj=self.contact, new_id=self.contact.getId())
+
     def test_rename_same_folder(self):
         # When renaming a folderish item with safe_id=True, and there is
         # already an existing folderish item with that id, it should choose


### PR DESCRIPTION
Fixes #361 