### PR TITLE
try..except the portal_groups AttributeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Change api.group.get_groups to work with CMF master.
+  [jaroel]
 
 
 1.8.1 (2017-10-17)

--- a/src/plone/api/group.py
+++ b/src/plone/api/group.py
@@ -91,9 +91,14 @@ def get_groups(username=None, user=None):
     group_tool = portal.get_tool('portal_groups')
 
     if user:
-        if not getattr(user, 'portal_groups', None):
-            return []
-        groups = group_tool.getGroupsForPrincipal(user)
+        try:
+            groups = group_tool.getGroupsForPrincipal(user)
+        except AttributeError as e:
+            # Anonymous users from the Zope acl_users folder will fail on this
+            if 'portal_groups' in e.message:
+                return[]
+            raise
+
         return [get(groupname=group) for group in groups]
 
     return group_tool.listGroups()


### PR DESCRIPTION
Should make this work for CMF master as well, where the memberdata object is an adapter and no longer acquisition wrapped as notified by David Glick.