### PR TITLE
fix #99 Call processForm with empty values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Call ``processForm`` with ``{None: None}`` dict as values.
+  This prevents ``processForm`` using ``REQUEST.form`` and overwriting 
+  values already set by ``invokeFactory``.
+  Fixes `issue 99 <https://github.com/plone/plone.api/issues/99>`_.
+  [david-batranu]
 
 
 1.8.2 (2018-01-17)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -112,7 +112,7 @@ def create(
         # rename-after-creation and such
         # Passing values as an empty dict so values set by invokeFactory
         # don't get overridden.
-        content.processForm(values={})
+        content.processForm(values={None: None})
 
     if not id or (safe_id and id):
         # Create a new id from title

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -110,8 +110,9 @@ def create(
     if IBaseObject.providedBy(content):
         # Will finish Archetypes content item creation process,
         # rename-after-creation and such
-        # Passing values as an empty dict so values set by invokeFactory
-        # don't get overridden.
+        # Passing values as a dict with None values so values set by
+        # invokeFactory don't get overridden.
+        # None: None is required so that bool(values) is True.
         content.processForm(values={None: None})
 
     if not id or (safe_id and id):

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -110,7 +110,9 @@ def create(
     if IBaseObject.providedBy(content):
         # Will finish Archetypes content item creation process,
         # rename-after-creation and such
-        content.processForm(values=kwargs)
+        # Passing values as an empty dict so values set by invokeFactory
+        # don't get overridden.
+        content.processForm(values={})
 
     if not id or (safe_id and id):
         # Create a new id from title

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -363,7 +363,7 @@ class TestPloneApiContent(unittest.TestCase):
             container=container,
             type='Folder',
             id='test-folder',
-            title='Test folder'
+            title='Test folder',
         )
         assert folder
         self.assertEqual(folder.id, 'test-folder')

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -345,6 +345,43 @@ class TestPloneApiContent(unittest.TestCase):
         # check that the exception is the one we raised
         self.assertEqual(ude.exception.reason, unicode_exception_message)
 
+    def test_create_at_with_title_in_request(self):
+        """ Test that content gets created with the correct title, even if
+            request.form['title'] already exists and has a different value.
+            This can occur, for example, when adding a Plone with an enabled
+            product that creates a site structure. In that case, the 'title'
+            would be that of the portal.
+            Only AT content types are affected, due to content.processForm.
+        """
+        leaked_title = 'This should not be set on content items'
+        self.layer['request'].form['title'] = leaked_title
+
+        container = self.portal
+
+        # Create a folder
+        folder = api.content.create(
+            container=container,
+            type='Folder',
+            id='test-folder',
+            title='Test folder'
+        )
+        assert folder
+        self.assertEqual(folder.id, 'test-folder')
+        self.assertEqual(folder.title, 'Test folder')
+        self.assertEqual(folder.portal_type, 'Folder')
+
+        # Create a document
+        page = api.content.create(
+            container=folder,
+            type='Document',
+            id='test-document',
+            title='Test document',
+        )
+        assert page
+        self.assertEqual(page.id, 'test-document')
+        self.assertEqual(page.title, 'Test document')
+        self.assertEqual(page.portal_type, 'Document')
+
     def test_get_constraints(self):
         """Test the constraints when content is fetched with get."""
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -362,25 +362,19 @@ class TestPloneApiContent(unittest.TestCase):
         folder = api.content.create(
             container=container,
             type='Folder',
-            id='test-folder',
             title='Test folder',
         )
-        assert folder
-        self.assertEqual(folder.id, 'test-folder')
+
         self.assertEqual(folder.title, 'Test folder')
-        self.assertEqual(folder.portal_type, 'Folder')
 
         # Create a document
         page = api.content.create(
             container=folder,
             type='Document',
-            id='test-document',
             title='Test document',
         )
-        assert page
-        self.assertEqual(page.id, 'test-document')
+
         self.assertEqual(page.title, 'Test document')
-        self.assertEqual(page.portal_type, 'Document')
 
     def test_get_constraints(self):
         """Test the constraints when content is fetched with get."""


### PR DESCRIPTION
From what I can see, widgets mostly do the right thing and return empty_marker if field.getName() is missing from the request. Perfect when programatically adding content through invokeFactory/api.content.create as the set values don't get modified.