### PR TITLE
Fixed regular expression in test for Plone version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed regular expression in test for Plone version.  [maurits]
 
 
 1.8.2 (2018-01-17)

--- a/src/plone/api/tests/test_env.py
+++ b/src/plone/api/tests/test_env.py
@@ -21,6 +21,12 @@ role_mapping = (
     ('rrr', ('Manager')),
 )
 
+# Version of Zope and Plone should be something like
+# 'X.Y' or 'X.Y.Z' or 'X.Y.Z.A'
+# It could also include a package status id (Alpha, Beta or RC).
+# When run against coredev, we may have a .devN suffix as well.
+version_regexp = '^(\d+(\.\d+){1,3})(a\d+|b\d+|rc\d+)?(\.dev\d)?$'
+
 
 class HasProtectedMethods(SimpleItem):
 
@@ -426,24 +432,13 @@ class TestPloneApiEnv(unittest.TestCase):
         """Tests that plone_version() returns Plone version."""
         from plone.api.env import plone_version
         self.assertTrue(isinstance(plone_version(), str))
-        # version should be something like 'X.Y' or 'X.Y.Z'
-        # it could also include a package status id (Alpha, Beta or RC)
-        # When run against coredev, we may have a .devN suffix as well.
-        self.assertRegexpMatches(
-            plone_version(),
-            '^(\d+\.\d+|\d+\.\d+\.\d+)(a\d+|b\d+|rc\d+)?(\.dev\d)?$',
-        )
+        self.assertRegexpMatches(plone_version(), version_regexp)
 
     def test_zope_version(self):
         """Tests that zope_version() returns Zope version."""
         from plone.api.env import zope_version
         self.assertTrue(isinstance(zope_version(), str))
-        # version should be something like 'X.Y' or 'X.Y.Z'
-        # it could also include a package status id (Alpha, Beta or RC)
-        self.assertRegexpMatches(
-            zope_version(),
-            '^(\d+\.\d+|\d+\.\d+\.\d+)(a\d+|b\d+|rc\d+)?(\.dev\d)?$',
-        )
+        self.assertRegexpMatches(zope_version(), version_regexp)
 
     def test_adopt_user_different_username(self):
         user = api.user.get(userid=TEST_USER_ID)


### PR DESCRIPTION
Plone 5.1.0.1 gives a [test failure on Jenkins](https://jenkins.plone.org/job/plone-5.1-python-2.7/1019/testReport/junit/plone.api.tests.test_env/TestPloneApiEnv/test_plone_version/), because the fourth level was not expected:

```
Regexp didn't match: '^(\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)(a\\d+|b\\d+|rc\\d+)?(\\.dev\\d)?$' not found in '5.1.0.1'

  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/.buildout/eggs/plone.api-1.8.2-py2.7.egg/plone/api/tests/test_env.py", line 434, in test_plone_version
    '^(\d+\.\d+|\d+\.\d+\.\d+)(a\d+|b\d+|rc\d+)?(\.dev\d)?$',
  File "/usr/lib/python2.7/unittest/case.py", line 1002, in assertRegexpMatches
    raise self.failureException(msg)
```

We could maybe use `pkg_resources.parse_version` or `distutils` or `packaging`. See [stackoverflow](https://stackoverflow.com/questions/11887762/compare-version-strings-in-python) for some options.
But I opted to change the regexp that we were using.