### PR TITLE
Fix falining AT Collection creation when using api.content.create.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Bug fixes:
 - fix typos in doc strings
   [tkimnguyen]
 
-- Fix falining AT Collection creation when using api.content.create.
+- Fix failing AT Collection creation when using api.content.create.
   [gbastien]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Bug fixes:
 - fix typos in doc strings
   [tkimnguyen]
 
+- Fix falining AT Collection creation when using api.content.create.
+  [gbastien]
+
 
 1.8.4 (2018-04-24)
 ------------------

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -112,8 +112,8 @@ def create(
         # rename-after-creation and such
         # Passing values as a dict with None values so values set by
         # invokeFactory don't get overridden.
-        # None: None is required so that bool(values) is True.
-        content.processForm(values={None: None})
+        # '': '' is required so that bool(values) is True.
+        content.processForm(values={'': ''})
 
     if not id or (safe_id and id):
         # Create a new id from title

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -376,9 +376,8 @@ class TestPloneApiContent(unittest.TestCase):
 
         self.assertEqual(page.title, 'Test document')
 
-    @unittest.skipIf(HAS_PACONTENTYPES, 'Archetypes only')
-    def test_create_at_collection(self):
-        """Test create at Collecition."""
+    def test_create_collection(self):
+        """Test create a Collection."""
         collection = api.content.create(
             container=self.portal,
             type='Collection',

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -376,6 +376,62 @@ class TestPloneApiContent(unittest.TestCase):
 
         self.assertEqual(page.title, 'Test document')
 
+    @unittest.skipIf(HAS_PACONTENTYPES, 'Archetypes only')
+    def test_create_at_collection(self):
+        """Test create at Collecition."""
+        collection = api.content.create(
+            container=self.portal,
+            type='Collection',
+            title='Mandelbrot set',
+            description='Image gallery of a zoom sequence',
+            query=[{
+                'i': 'Type',
+                'o': 'plone.app.querystring.operation.string.is',
+                'v': ['Image'],
+            }],
+        )
+        self.assertEqual(collection.Title(), 'Mandelbrot set')
+
+    @unittest.skipIf(HAS_PACONTENTYPES, 'Archetypes only')
+    def test_create_at_event(self):
+        """https://github.com/plone/plone.api/issues/364"""
+        from DateTime import DateTime
+        today = DateTime()
+        tomorrow = today + 1
+        event = api.content.create(
+            container=self.portal,
+            type='Event',
+            title=u'My event',
+            startDate=today,
+            endDate=tomorrow,
+        )
+        self.assertEqual(event.startDate, today)
+        self.assertEqual(event.endDate, tomorrow)
+        results = api.content.find(Title=u'My event')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].start, today)
+        self.assertEqual(results[0].end, tomorrow)
+
+    @unittest.skipUnless(HAS_PACONTENTYPES, 'Dexterity only')
+    def test_create_dx_event(self):
+        """https://github.com/plone/plone.app.contenttypes/issues/465"""
+        import datetime
+        today = datetime.datetime.now()
+        tomorrow = today + datetime.timedelta(days=1)
+        event = api.content.create(
+            container=self.portal,
+            type='Event',
+            title=u'My event',
+            start=today,
+            end=tomorrow,
+        )
+        self.assertEqual(event.start, today)
+        self.assertEqual(event.end, tomorrow)
+        results = api.content.find(Title=u'My event')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].start, today)
+        self.assertEqual(results[0].end, tomorrow)
+
     def test_get_constraints(self):
         """Test the constraints when content is fetched with get."""
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -384,11 +384,13 @@ class TestPloneApiContent(unittest.TestCase):
             type='Collection',
             title='Mandelbrot set',
             description='Image gallery of a zoom sequence',
-            query=[{
-                'i': 'Type',
-                'o': 'plone.app.querystring.operation.string.is',
-                'v': ['Image'],
-            }],
+            query=[
+                {
+                 'i': 'Type',
+                 'o': 'plone.app.querystring.operation.string.is',
+                 'v': ['Image'],
+                },
+            ],
         )
         self.assertEqual(collection.Title(), 'Mandelbrot set')
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -415,7 +415,7 @@ class TestPloneApiContent(unittest.TestCase):
 
     @unittest.skipUnless(HAS_PACONTENTYPES, 'Dexterity only')
     def test_create_dx_event(self):
-        """ """
+        """Test create a DX event."""
         import datetime
         today = datetime.datetime.now()
         tomorrow = today + datetime.timedelta(days=1)

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -415,7 +415,7 @@ class TestPloneApiContent(unittest.TestCase):
 
     @unittest.skipUnless(HAS_PACONTENTYPES, 'Dexterity only')
     def test_create_dx_event(self):
-        """https://github.com/plone/plone.app.contenttypes/issues/465"""
+        """ """
         import datetime
         today = datetime.datetime.now()
         tomorrow = today + datetime.timedelta(days=1)


### PR DESCRIPTION
I also added the AT/DX event creation related tests from PR #407.

With this, the Collection creation is correct.

Thank you,

Gauthier