### PR TITLE
Show only local roles when inherit=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Show only local roles when inherit=False.
+  [tschorr]
 
 
 1.9.0 (2018-09-27)
@@ -34,7 +35,7 @@ Bug fixes:
 - Removed allow-hosts from base.cfg, so we can use the new pypi warehouse.
   Refs https://github.com/plone/plone.api/issues/403
   [jaroel]
-  
+
 - fix typos in doc strings
   [tkimnguyen]
 

--- a/src/plone/api/group.py
+++ b/src/plone/api/group.py
@@ -216,6 +216,8 @@ def get_roles(groupname=None, group=None, obj=None, inherit=True):
     :type group: GroupData object
     :param obj: If obj is set then return local roles on this context.
     :type obj: content object
+    :param inherit: Show only local roles if False
+    :type inherit: boolean
     :raises:
         ValueError
     :Example: :ref:`group_get_roles_example`
@@ -239,17 +241,12 @@ def get_roles(groupname=None, group=None, obj=None, inherit=True):
     else:
         # get only the local roles on a object
         # same as above we use the PloneUser version of getRolesInContext.
-        # Include roles inherited from being the member of a group
-        # and from adapters granting local roles
-        plone_user = super(group.__class__, group)
-        principal_ids = list(plone_user.getGroups())
-        principal_ids.insert(0, plone_user.getId())
+        # Include roles from adapters granting local roles
         roles = set([])
         pas = portal.get_tool('acl_users')
         for _, lrmanager in pas.plugins.listPlugins(ILocalRolesPlugin):
             for adapter in lrmanager._getAdapters(obj):
-                for principal_id in principal_ids:
-                    roles.update(adapter.getRoles(principal_id))
+                roles.update(adapter.getRoles(group_id))
         return list(roles)
 
 

--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -775,3 +775,32 @@ class TestPloneApiGroup(unittest.TestCase):
             ROLES,
             set(api.group.get_roles(group=group, obj=document)),
         )
+
+    def test_local_roles_no_inheritance(self):
+        """Test possibility to disregard roles
+        for inherited groups."""
+        api.group.create(groupname='ploneboat')
+        portal = api.portal.get()
+        folder = api.content.create(
+            container=portal,
+            type='Folder',
+            id='folder_one',
+            title='Folder One',
+        )
+        document = api.content.create(
+            container=folder,
+            type='Document',
+            id='document_one',
+            title='Document One',
+        )
+        api.group.grant_roles(
+            groupname='ploneboat',
+            roles=['Reviewer', 'Editor'],
+            obj=document,
+        )
+        document.manage_setLocalRoles(
+            'AuthenticatedUsers', ('Reader',))
+        self.assertNotIn(
+            'Reader',
+            api.group.get_roles(groupname='ploneboat', inherit=False, obj=document)
+        )

--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -802,5 +802,6 @@ class TestPloneApiGroup(unittest.TestCase):
             'AuthenticatedUsers', ('Reader',))
         self.assertNotIn(
             'Reader',
-            api.group.get_roles(groupname='ploneboat', inherit=False, obj=document)
+            api.group.get_roles(
+                groupname='ploneboat', inherit=False, obj=document),
         )

--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -798,10 +798,8 @@ class TestPloneApiGroup(unittest.TestCase):
             roles=['Reviewer', 'Editor'],
             obj=document,
         )
-        document.manage_setLocalRoles(
-            'AuthenticatedUsers', ('Reader',))
+        document.manage_setLocalRoles('AuthenticatedUsers', ('Reader',))
         self.assertNotIn(
             'Reader',
-            api.group.get_roles(
-                groupname='ploneboat', inherit=False, obj=document),
+            api.group.get_roles(groupname='ploneboat', inherit=False, obj=document),  # noqa: E501
         )


### PR DESCRIPTION
When using `api.group.get_roles` with `inherit=False`, inherited roles from group memberships are shown along with local roles from adapters. This is inconsistent with what is displayed in the ZMI's `manage_listLocalRoles` and `@@sharing`. E.g. if you grant a local role to `AuthenticatedUsers` it is returned by `get_roles` for all other groups.

Suggestion: change behavior of `get_roles` when called with `inherit=False` to return only local roles for the requested group to make it consistent with ZMI and sharing tab.

Alternatively there could be an additional parameter/flag to make `get_roles` return only local roles.