### PR TITLE
Fixed test failures on Python 3 with Products.MailHost 4.10.

### DIFF
--- a/docs/portal.rst
+++ b/docs/portal.rst
@@ -218,8 +218,13 @@ To send an e-mail use :meth:`api.portal.send_email`:
 
     self.assertEqual(len(mailhost.messages), 1)
 
-    from email import message_from_string
-    msg = message_from_string(mailhost.messages[0])
+    try:
+        # Python 3
+        from email import message_from_bytes
+    except ImportError:
+        # Python 2
+        from email import message_from_string as message_from_bytes
+    msg = message_from_bytes(mailhost.messages[0])
     self.assertEqual(msg['To'], 'bob@plone.org')
     self.assertEqual(msg['From'], 'noreply@plone.org')
     self.assertEqual(msg['Subject'], '=?utf-8?q?Trappist?=')
@@ -256,7 +261,7 @@ Python's standard `email module <https://docs.python.org/2.7/library/email.messa
 
     self.assertEqual(len(mailhost.messages), 2)
 
-    msg = message_from_string(mailhost.messages[1])
+    msg = message_from_bytes(mailhost.messages[1])
     payloads = msg.get_payload()
     self.assertEqual(len(payloads), 2)
     self.assertEqual(msg['Reply-To'], 'community@plone.org')

--- a/news/3178.bugfix
+++ b/news/3178.bugfix
@@ -1,0 +1,2 @@
+Fixed test failures on Python 3 with Products.MailHost 4.10.
+[maurits]

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -3,7 +3,6 @@
 
 from datetime import date
 from datetime import datetime
-from email import message_from_string
 from pkg_resources import parse_version
 from plone.api import content
 from plone.api import env
@@ -25,6 +24,13 @@ from zope.site import LocalSiteManager
 import DateTime
 import mock
 import unittest
+
+try:
+    # Python 3
+    from email import message_from_bytes
+except ImportError:
+    # Python 2
+    from email import message_from_string as message_from_bytes
 
 
 HAS_PLONE5 = parse_version(env.plone_version()) >= parse_version('5.0b2')
@@ -228,7 +234,7 @@ class TestPloneApiPortal(unittest.TestCase):
         )
 
         self.assertEqual(len(self.mailhost.messages), 1)
-        msg = message_from_string(self.mailhost.messages[0])
+        msg = message_from_bytes(self.mailhost.messages[0])
         self.assertEqual(msg['To'], 'bob@plone.org')
         self.assertEqual(msg['From'], 'noreply@plone.org')
         self.assertEqual(msg['Subject'], '=?utf-8?q?Trappist?=')
@@ -243,7 +249,7 @@ class TestPloneApiPortal(unittest.TestCase):
         )
 
         self.assertEqual(len(self.mailhost.messages), 1)
-        msg = message_from_string(self.mailhost.messages[0])
+        msg = message_from_bytes(self.mailhost.messages[0])
         self.assertEqual(msg['From'], 'Portal Owner <sender@example.org>')
 
     def test_send_email_without_configured_mailhost(self):
@@ -302,7 +308,7 @@ class TestPloneApiPortal(unittest.TestCase):
             body=u'One for you Bob!',
         )
         self.assertEqual(len(self.mailhost.messages), 1)
-        msg = message_from_string(self.mailhost.messages[0])
+        msg = message_from_bytes(self.mailhost.messages[0])
         self.assertEqual(msg['From'], 'Properties <prop@example.org>')
 
     @unittest.skipUnless(
@@ -328,7 +334,7 @@ class TestPloneApiPortal(unittest.TestCase):
             body=u'One for you Bob!',
         )
         self.assertEqual(len(self.mailhost.messages), 1)
-        msg = message_from_string(self.mailhost.messages[0])
+        msg = message_from_bytes(self.mailhost.messages[0])
         self.assertEqual(msg['From'], 'Registry <reg@example.org>')
 
     def test_send_email_with_printingmailhost(self):

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -25,6 +25,7 @@ import DateTime
 import mock
 import unittest
 
+
 try:
     # Python 3
     from email import message_from_bytes


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3178
Needs to be tested and merged together with other PRs.