### PR TITLE
Fix plone.api.content.find to respect object_provides "not" queries.

### DIFF
--- a/news/452.bugfix
+++ b/news/452.bugfix
@@ -1,0 +1,3 @@
+Fix plone.api.content.find to respect object_provides "not" queries.
+Fixes: #451
+[thet]

--- a/news/452.feature
+++ b/news/452.feature
@@ -1,0 +1,2 @@
+Adapt flake8 to Plone/black standards.
+[thet]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,11 +4,8 @@ ignore =
     .travis.yml
 
 [flake8]
-exclude =
-    bootstrap-buildout.py,
-
-ignore =
-    W503
+max-line-length = 88
+extend-ignore = E203, W503
 
 [isort]
 force_alphabetical_sort=True

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -594,18 +594,35 @@ def _parse_object_provides_query(query):
         query for multiple values
         (eg. `{'query': [Iface1, Iface2], 'operator': 'or'}`)
     """
-    operator = 'or'
     ifaces = query
-    if isinstance(query, dict):
-        operator = query.get('operator', operator)
-        ifaces = query.get('query', [])
-    elif not isinstance(query, (list, tuple)):
-        ifaces = [query]
+    operator = 'or'
+    query_not = []
 
-    return {
-        'query': [getattr(x, '__identifier__', x) for x in ifaces],
-        'operator': operator,
-    }
+    if isinstance(query, dict):
+        ifaces = query.get('query', [])
+        operator = query.get('operator', operator)
+        query_not = query.get('not', [])
+        # KeywordIndex also supports "range",
+        # but that's not useful for querying object_provides
+
+    if not isinstance(ifaces, (list, tuple)):
+        ifaces = [ifaces]
+    ifaces = [getattr(x, '__identifier__', x) for x in ifaces]
+
+    if not isinstance(query_not, (list, tuple)):
+        query_not = [query_not]
+    query_not = [getattr(x, '__identifier__', x) for x in query_not]
+
+    result = {}
+
+    if ifaces:
+        result['query'] = ifaces
+        result['operator'] = operator
+
+    if query_not:
+        result['not'] = query_not
+
+    return result
 
 
 def find(context=None, depth=None, **kwargs):

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -5,7 +5,10 @@ from Acquisition import aq_base
 from OFS.CopySupport import CopyError
 from OFS.event import ObjectWillBeMovedEvent
 from OFS.interfaces import IObjectWillBeMovedEvent
+from pkg_resources import parse_version
 from plone import api
+from plone.api import env
+from plone.api.content import _parse_object_provides_query
 from plone.api.content import NEW_LINKINTEGRITY
 from plone.api.tests.base import INTEGRATION_TESTING
 from plone.app.layout.navigation.interfaces import INavigationRoot
@@ -40,6 +43,9 @@ except pkg_resources.DistributionNotFound:
     HAS_PACONTENTYPES = False
 else:
     HAS_PACONTENTYPES = True
+
+
+HAS_PLONE51 = parse_version(env.plone_version()) >= parse_version('5.1')
 
 
 class TestPloneApiContent(unittest.TestCase):
@@ -1048,6 +1054,78 @@ class TestPloneApiContent(unittest.TestCase):
             },
         )
         self.assertEqual(len(brains), 1)
+
+    @unittest.skipUnless(
+        HAS_PLONE51,
+        'Negative queries only available since Products.ZCatalog 3.0a1 or Plone 5.1',
+    )
+    def test_find_interface_dict__include_not_query(self):
+        """Check if not query in object_provides is functional.
+        """
+
+        brains_all = api.content.find(
+            object_provides={'query': IContentish.__identifier__},
+        )
+
+        alsoProvides(self.portal.events, INavigationRoot)
+        self.portal.events.reindexObject(idxs=['object_provides'])
+
+        brains = api.content.find(
+            object_provides={
+                'query': IContentish.__identifier__,
+                'not': INavigationRoot.__identifier__
+            },
+        )
+
+        self.assertEqual(len(brains_all) - len(brains), 1)
+
+    def test_find_interface_dict__all_options(self):
+        """ Check for all options in a object_provides query are correctly
+        transformed.
+        """
+        parser = _parse_object_provides_query
+
+        self.assertDictEqual(
+            parser({'query': IContentish}),
+            {'query': [IContentish.__identifier__], 'operator': 'or'},
+        )
+
+        self.assertDictEqual(
+            parser(
+                {
+                    'query': [IContentish, INavigationRoot.__identifier__],
+                    'operator': 'and'
+                }
+            ),
+            {
+                'query': [IContentish.__identifier__, INavigationRoot.__identifier__],
+                'operator': 'and'
+            },
+        )
+
+        self.assertDictEqual(
+            parser({'not': IContentish}),
+            {'not': [IContentish.__identifier__]},
+        )
+
+        self.assertDictEqual(
+            parser({'not': [IContentish, INavigationRoot.__identifier__]}),
+            {'not': [IContentish.__identifier__, INavigationRoot.__identifier__]},
+        )
+
+        self.assertDictEqual(
+            parser({'not': IContentish}),
+            {'not': [IContentish.__identifier__]},
+        )
+
+        self.assertDictEqual(
+            parser({'query': IContentish, 'operator': 'and', 'not': INavigationRoot}),
+            {
+                'query': [IContentish.__identifier__],
+                'operator': 'and',
+                'not': [INavigationRoot.__identifier__],
+            },
+        )
 
     def test_find_dict(self):
         # Pass arguments using dict

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -5,9 +5,7 @@ from Acquisition import aq_base
 from OFS.CopySupport import CopyError
 from OFS.event import ObjectWillBeMovedEvent
 from OFS.interfaces import IObjectWillBeMovedEvent
-from pkg_resources import parse_version
 from plone import api
-from plone.api import env
 from plone.api.content import _parse_object_provides_query
 from plone.api.content import NEW_LINKINTEGRITY
 from plone.api.tests.base import INTEGRATION_TESTING
@@ -43,9 +41,6 @@ except pkg_resources.DistributionNotFound:
     HAS_PACONTENTYPES = False
 else:
     HAS_PACONTENTYPES = True
-
-
-HAS_PLONE51 = parse_version(env.plone_version()) >= parse_version('5.1')
 
 
 class TestPloneApiContent(unittest.TestCase):
@@ -1055,10 +1050,6 @@ class TestPloneApiContent(unittest.TestCase):
         )
         self.assertEqual(len(brains), 1)
 
-    @unittest.skipUnless(
-        HAS_PLONE51,
-        'Negative queries only available since Products.ZCatalog 3.0a1 or Plone 5.1',
-    )
     def test_find_interface_dict__include_not_query(self):
         """Check if not query in object_provides is functional.
         """

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -1064,7 +1064,7 @@ class TestPloneApiContent(unittest.TestCase):
         brains = api.content.find(
             object_provides={
                 'query': IContentish.__identifier__,
-                'not': INavigationRoot.__identifier__
+                'not': INavigationRoot.__identifier__,
             },
         )
 
@@ -1085,12 +1085,12 @@ class TestPloneApiContent(unittest.TestCase):
             parser(
                 {
                     'query': [IContentish, INavigationRoot.__identifier__],
-                    'operator': 'and'
-                }
+                    'operator': 'and',
+                },
             ),
             {
                 'query': [IContentish.__identifier__, INavigationRoot.__identifier__],
-                'operator': 'and'
+                'operator': 'and',
             },
         )
 


### PR DESCRIPTION
Fix plone.api.content.find to respect object_provides "not" queries.
Fixes: #451

Actually a revert, as I unintentionally commited to master before :|

```
Revert "Revert "Fix plone.api.content.find to respect object_provides "not" queries.""

This reverts commit 8f6533373ccfa6ce973afb0daa680cda0e986668.
```