### PR TITLE
Tox: only test docs, verbose, and run with 3.7, 3.8 and 3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
   include:
       - python: "3.7"
         env: TOXENV=docs
-      - python: "3.8"
-        env: TOXENV=docs
-      - python: "3.9"
-        env: TOXENV=docs
 
 before_install:
     - mkdir -p $HOME/buildout-cache/{downloads,eggs,extends}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,12 @@ global:
 matrix:
   fast_finish: true
   include:
-      - python: "3.8"
-        env: TOXENV=isort,lint
+      - python: "3.7"
+        env: TOXENV=docs
       - python: "3.8"
         env: TOXENV=docs
-      - python: "2.7"
-        env: TOXENV=py27-plone-5.2
-      - python: "2.7"
-        env: TOXENV=py27-plone-5.2-archetypes
-      - python: "3.6"
-        env: TOXENV=py36-plone-5.2
-      - python: "3.7"
-        env: TOXENV=py37-plone-5.2
-      - python: "3.8"
-        env: TOXENV=py38-plone-5.2
+      - python: "3.9"
+        env: TOXENV=docs
 
 before_install:
     - mkdir -p $HOME/buildout-cache/{downloads,eggs,extends}

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,7 @@ whitelist_externals =
     mkdir
 
 [testenv:docs]
-basepython = python
+basepython = python3.7
 skip_install = False
 usedevelop = True
 extras =
@@ -151,7 +151,7 @@ deps =
 commands =
     python -VV
     mkdir -p {toxinidir}/_build/docs
-    sphinx-build -vvv -b html -d _build/docs/doctrees docs _build/docs/html
+    sphinx-build -b html -d _build/docs/doctrees docs _build/docs/html
 #    sphinx-build -b doctest docs _build/docs/doctrees
 
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,7 @@ deps =
 commands =
     python -VV
     mkdir -p {toxinidir}/_build/docs
-    sphinx-build -b html -d _build/docs/doctrees docs _build/docs/html
+    sphinx-build -vvv -b html -d _build/docs/doctrees docs _build/docs/html
 #    sphinx-build -b doctest docs _build/docs/doctrees
 
 whitelist_externals =


### PR DESCRIPTION
On Travis the sphinx docs fail with no output after ten minutes.

This PR not meant to be merged, this is only for investigation.
Based on https://github.com/plone/plone.api/pull/453