### PR TITLE
Verify intids in tests

### DIFF
--- a/news/430.bugfix
+++ b/news/430.bugfix
@@ -1,0 +1,2 @@
+Add tests to verify that the intids utility is correct after moving content.
+[ale-rt, maurits]

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -113,7 +113,7 @@ class TestPloneApiContent(unittest.TestCase):
             id='image',
         )
 
-    def verify_initids(self):
+    def verify_intids(self):
         """Test that the intids are in order"""
         try:
             from zope.intid.interfaces import IIntIds
@@ -259,7 +259,7 @@ class TestPloneApiContent(unittest.TestCase):
                 type='Dexterity Item',
                 id='test-item',
             )
-        self.verify_initids()
+        self.verify_intids()
 
     def test_create_content(self):
         """Test create content"""
@@ -307,7 +307,7 @@ class TestPloneApiContent(unittest.TestCase):
                 type='Document',
                 id='test-document',
             )
-        self.verify_initids()
+        self.verify_intids()
 
     def test_create_with_safe_id(self):
         """Test the content creating with safe_id mode."""
@@ -571,7 +571,7 @@ class TestPloneApiContent(unittest.TestCase):
             container['events']['about']
             and container['events']['about'] == about
         )
-        self.verify_initids()
+        self.verify_intids()
 
     def test_move_no_move_if_target_is_source_parent(self):
         """Test that trying to move an object to its parent is a noop"""

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -115,12 +115,9 @@ class TestPloneApiContent(unittest.TestCase):
 
     def verify_intids(self):
         """Test that the intids are in order"""
-        try:
-            from zope.intid.interfaces import IIntIds
-        except ImportError:
-            # IntId are not a thing in Plone 4.3
-            return
         from zope.component import getUtility
+        from zope.intid.interfaces import IIntIds
+
         intids = getUtility(IIntIds)
         broken_keys = [
             key for key in intids.ids

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -113,6 +113,23 @@ class TestPloneApiContent(unittest.TestCase):
             id='image',
         )
 
+    def verify_initids(self):
+        """Test that the intids are in order"""
+        try:
+            from zope.intid.interfaces import IIntIds
+        except ImportError:
+            # IntId are not a thing in Plone 4.3
+            return
+        from zope.component import getUtility
+        intids = getUtility(IIntIds)
+        broken_keys = [
+            key for key in intids.ids
+            if not self.portal.unrestrictedTraverse(key.path, None)
+        ]
+        obsolete_paths = [key.path for key in broken_keys]
+        self.assertListEqual(obsolete_paths, [])
+
+
     def test_create_constraints(self):
         """Test the constraints when creating content."""
         from plone.api.exc import InvalidParameterError
@@ -242,6 +259,7 @@ class TestPloneApiContent(unittest.TestCase):
                 type='Dexterity Item',
                 id='test-item',
             )
+        self.verify_initids()
 
     def test_create_content(self):
         """Test create content"""
@@ -289,6 +307,7 @@ class TestPloneApiContent(unittest.TestCase):
                 type='Document',
                 id='test-document',
             )
+        self.verify_initids()
 
     def test_create_with_safe_id(self):
         """Test the content creating with safe_id mode."""
@@ -552,6 +571,7 @@ class TestPloneApiContent(unittest.TestCase):
             container['events']['about']
             and container['events']['about'] == about
         )
+        self.verify_initids()
 
     def test_move_no_move_if_target_is_source_parent(self):
         """Test that trying to move an object to its parent is a noop"""

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -126,6 +126,14 @@ class TestPloneApiContent(unittest.TestCase):
         obsolete_paths = [key.path for key in broken_keys]
         self.assertListEqual(obsolete_paths, [])
 
+        # Objects used as keys with a hash can behave strangely.
+        # I have seen this go wrong in a production site.
+        weird_keys = [
+            key for key in intids.ids
+            if key not in intids.ids
+        ]
+        weird_paths = [key.path for key in weird_keys]
+        self.assertListEqual(weird_paths, [])
 
     def test_create_constraints(self):
         """Test the constraints when creating content."""


### PR DESCRIPTION
This cherry-picks the [`demo-broken-intids` branch](https://github.com/plone/plone.api/tree/demo-broken-intids) that @ale-rt created in 2019 to demonstrate an issue (#430) with intids after moving content. His [workaround](https://github.com/plone/five.intid/pull/8) from that time is I think the correct permanent solution, as I [discuss here](https://github.com/plone/five.intid/issues/9#issuecomment-802940554).

I added extra verification. Tox passes locally.