### PR TITLE
Fixed IndexError when calling set_registry_record with wrong value. [1.x]

### DIFF
--- a/news/435.bugfix
+++ b/news/435.bugfix
@@ -1,0 +1,2 @@
+Fixed IndexError when calling set_registry_record with wrong value.
+[maurits]

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -372,11 +372,11 @@ def set_registry_record(name=None, value=None, interface=None):
         try:
             registry[interface.__identifier__ + '.' + name] = value
         except WrongType:
-            field_type = [
-                field[1]
-                for field in interface.namesAndDescriptions()
-                if field[0] == 'field_one'
-            ][0]
+            field_type = None
+            for field in interface.namesAndDescriptions():
+                if field[0] == name:
+                    field_type = field[1]
+                    break
             raise InvalidParameterError(
                 u'The value parameter for the field {name} needs to be '
                 u'{of_class} instead of {of_type}'.format(

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -50,6 +50,14 @@ class IMyRegistrySettings(Interface):
     )
 
 
+class IMyOtherRegistrySettings(Interface):
+
+    field_three = schema.TextLine(
+        title=u'something',
+        description=u'something else',
+    )
+
+
 class ImNotAnInterface(object):
     pass
 
@@ -735,6 +743,29 @@ class TestPloneApiPortal(unittest.TestCase):
             ),
             text,
         )
+
+    def test_set_registry_record_with_invalid_value(self):
+        """Test setting an invalid value on a record from an interface.
+
+        This should give an invalid parameter error.
+        See also https://github.com/plone/plone.api/issues/435
+        and duplicate: https://github.com/plone/plone.api/issues/464
+        """
+        from plone.api.exc import InvalidParameterError
+        registry = getUtility(IRegistry)
+        registry.registerInterface(IMyOtherRegistrySettings)
+        with self.assertRaises(InvalidParameterError) as cm:
+            portal.set_registry_record(
+                'field_three',
+                42,
+                interface=IMyOtherRegistrySettings,
+            )
+        exc_str = str(cm.exception)
+
+        self.assertIn(
+            "The value parameter for the field field_three", exc_str
+        )
+        self.assertIn("TextLine", exc_str)
 
     def test_set_registry_record_on_invalid_interface(self):
         """Test that passing an invalid interface raises an Exception."""


### PR DESCRIPTION
Fixes https://github.com/plone/plone.api/issues/435

This is for 1.x. I will port to master as well.