### PR TITLE
Integration of plone.api documentation in Plone 6 documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /pip-selfcheck.json
 /_build/
 /.tox/
+pyvenv.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ Changelog
 2.0.0a2 (2021-10-13)
 --------------------
 
+New features:
+
+
+- Preview of documentation per pull request. Netlify bot adds link in PR comments. [ksuess]
+- Integration in new Plone 6 documentation [ksuess]
+
 Bug fixes:
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+SHELL := /bin/bash
+CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+version = 3
+
+# We like colors
+# From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+RESET=`tput sgr0`
+YELLOW=`tput setaf 3`
+
+
+# all: .installed.cfg
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+.PHONY: help
+help: ## This help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+
+bin/python bin/pip:
+	python$(version) -m venv . || virtualenv --python=python$(version) .
+	bin/python -m pip install --upgrade pip
+
+
+# Documentation
+# ----------------------------------------------------------------------
+
+.PHONY: netlify
+netlify:
+	bin/pip install tox
+	tox -e plone6docs
+	@echo
+	@echo "Build finished. The HTML pages are in _build/plone6docs/html."
+

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bin/python bin/pip:
 .PHONY: netlify
 netlify: bin/python bin/pip
 	bin/pip install tox
-	tox -e plone6docs
+	bin/tox -e plone6docs
 	@echo
 	@echo "Build finished. The HTML pages are in _build/plone6docs/html."
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bin/python bin/pip:
 # ----------------------------------------------------------------------
 
 .PHONY: netlify
-netlify:
+netlify: bin/python bin/pip
 	bin/pip install tox
 	tox -e plone6docs
 	@echo

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -75,7 +75,7 @@ api.group
 
 
 api.env
----------
+-------
 
 .. autosummary::
 
@@ -86,7 +86,7 @@ api.env
 
 
 api.relation
----------
+------------
 
 .. autosummary::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,16 @@ class Mock:
         else:
             return Mock()
 
+
 MOCK_MODULES = ['lxml']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_book_theme"
+

--- a/docs/contribute/conventions.rst
+++ b/docs/contribute/conventions.rst
@@ -1,4 +1,0 @@
-.. note::
-
-    This documentation was moved to the `styleguide section on docs.plone.org <http://docs.plone.org/develop/styleguide/>`_, to the `Working with Git and GitHub <http://docs.plone.org/develop/coredev/docs/git.html>`_ and to the :doc:`develop` chapter of the plone.api documentation.
-

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -50,18 +50,15 @@ First let's look at 'system' libraries and applications that are normally instal
 Python tools
 ------------
 
-.. todo::
+* tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.
 
-    Update this description:
+Build the documentation with
 
-    * add tox and propably pip.
-    * easy_install should be removed.
-    * question if virtualenv should be used, as tox also replaces this step.
+.. sourcecode:: bash
 
-Then you'll also need to install some Python specific tools:
+    tox -e docs
 
-* easy_install - the Python packaging system (download http://peak.telecommunity.com/dist/ez_setup.py and run ``sudo python2.7 ez_setup.py``.
-* virtualenv - a tool that assists in creating isolated Python working environments. Run ``sudo easy_install virtualenv`` after your have installed   `easy_install` above.
+The HTML pages are in _build/docs/html.
 
 .. note::
 

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -50,8 +50,7 @@ First let's look at 'system' libraries and applications that are normally instal
 Python tools
 ------------
 
-* tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.  
-Install with `pip install tox`
+* tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software. Install with `pip install tox`.
 
 Build the documentation with
 

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -72,10 +72,10 @@ Further information
 
 If you experience problems read through the following links as almost all of the above steps are required for a default Plone development environment:
 
-* http://plone.org/documentation/tutorial/buildout
+* https://docs.plone.org/manage/index.html
 * http://pypi.python.org/pypi/zc.buildout/
 * http://pypi.python.org/pypi/setuptools
-* http://plone.org/documentation/manual/installing-plone
+* https://plone.org/download
 
 If you are an OS X user, you first need a working Python implementation
 (the one that comes with the operating system is broken).
@@ -177,7 +177,7 @@ Once we are happy with your implementation, your branch gets merged into *master
     them; in other words, others can comment on your code without your code
     changing their development environments
 
-Read more about Git branching at http://learn.github.com/p/branching.html and on our Git workflow at `Working with Git and GitHub <http://docs.plone.org/develop/coredev/docs/git.html>`_.
+Read more about Git branching at https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches and on our Git workflow at `Working with Git and GitHub <http://docs.plone.org/develop/coredev/docs/git.html>`_.
 
 
 Once you are done with your work and you would like us to merge your changes into master, go to GitHub to do a *pull request*.

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -52,14 +52,6 @@ Python tools
 
 * tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software. Install with `pip install tox`.
 
-Build the documentation with
-
-.. sourcecode:: bash
-
-    tox -e docs
-
-The HTML pages are in _build/docs/html.
-
 .. note::
 
     Again, OS X users should use https://github.com/collective/buildout.python,
@@ -197,8 +189,7 @@ Commit checklist
 Before every commit you should:
 
 * Run unit tests and syntax validation checks.
-* Add an entry to :ref:`changes` (if applicable).
-* Add/modify :ref:`sphinx-docs` (if applicable).
+* Add an entry to `CHANGES.rst` (if applicable).
 
 All syntax checks and all tests can be run with a single command.
 This command also re-generates your documentation.
@@ -224,11 +215,13 @@ Travis is configured with the ``.travis.yml`` file located in the root of this p
 Sphinx Documentation
 ====================
 
-Un-documented code is broken code.
+::
+
+    Un-documented code is broken code.
 
 For every feature you add to the codebase you should also add documentation for it to ``docs/``.
 
-After adding/modifying documentation, run ``make`` to re-generate your docs.
+After adding/modifying documentation, run `tox -e docs` to re-generate your docs.
 
 Publicly available documentation on http://api.plone.org is automatically generated from these source files, periodically.
 So when you push changes to master on GitHub you should soon be able to see them published on ``api.plone.org``.

--- a/docs/contribute/develop.rst
+++ b/docs/contribute/develop.rst
@@ -50,7 +50,8 @@ First let's look at 'system' libraries and applications that are normally instal
 Python tools
 ------------
 
-* tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.
+* tox automation - tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.  
+Install with `pip install tox`
 
 Build the documentation with
 

--- a/docs/relation.rst
+++ b/docs/relation.rst
@@ -23,7 +23,7 @@ Get relations
 
     api.relation.get(source=source, target=target, relationship="friend", unrestricted=False, as_dict=False)
 
-You must provide either source, target or relationship, or a combination of those.
+You must provide either source, target or relationship, or a combination of those to :meth:`api.relation.get`.
 ``unrestricted`` and ``as_dict`` are optional.
 
 By default the result is a list of ``RelationValue`` objects.
@@ -80,7 +80,7 @@ Delete one or more relations:
 
     api.relation.delete(source=source, target=target, relationship="friend")
 
-In order to delete relation(s), you must provide either ``source``, ``target`` or ``relationship``.
+In order to delete relation(s), you must provide either ``source``, ``target`` or ``relationship`` to :meth:`api.relation.delete`.
 You can mix and match.
 
 Delete all relations from source to any target:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+  PYTHON_VERSION = "3.9"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,5 @@
 [build.environment]
   PYTHON_VERSION = "3.9"
+
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  PYTHON_VERSION = "3.9"
+  PYTHON_VERSION = "3.8"
 
 [build]
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs/"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinx-book-theme<=0.3.99

--- a/src/plone/api/relation.py
+++ b/src/plone/api/relation.py
@@ -140,12 +140,10 @@ def create(source=None, target=None, relationship=None):
     :type source: Content object
     :param target: [required] Object that the relation will point to.
     :type target: Content object
-    :param relationship: [required] Relationship name. If that name is the same
-    as a field name and this field is a RelationChoice/RelationList we will
-    update the field-value accordingly.
+    :param relationship: [required] Relationship name. If that name is the same as a field name and this field is a RelationChoice / RelationList we will update the field-value accordingly.
     :type id: string
     :Example: :ref:`relation_create_example`
-    """
+    """  # noqa
     if source is not None and not base_hasattr(source, 'portal_type'):
         raise InvalidParameterError('{} has no portal_type'.format(source))
 

--- a/tox.ini
+++ b/tox.ini
@@ -145,7 +145,7 @@ extras =
     tests
 
 deps =
-    Sphinx
+    -r requirements-docs.txt
 
 commands =
     python -VV

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,7 @@ deps =
 
 commands =
     python -VV
-    mkdir -p {toxinidir}/_build/docs
+    mkdir -p {toxinidir}/_build/plone6docs
     sphinx-build -b html -d _build/plone6docs/doctrees docs _build/plone6docs/html
 #    sphinx-build -b doctest docs _build/docs/doctrees
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
     py{36,37,38}-plone-{5.2},
-    docs,
 #    black-check,
     isort,
     lint,
     coverage-report,
+    plone6docs,
+    docs
 
 skip_missing_interpreters = False
 
@@ -134,10 +135,10 @@ commands =
 whitelist_externals =
     mkdir
 
-[testenv:docs]
-# Locally for Maurits this only works with Python 2.7.
-# Travis is happy with 3.7, not with 3.8 or 3.9.
-# So pick the right one in .travis.yml (or GitHub Actions).
+
+[testenv:plone6docs]
+# New docs with sphinx-book-theme
+# See [testenv:docs] for classic documentation
 basepython = python
 skip_install = False
 usedevelop = True
@@ -150,11 +151,32 @@ deps =
 commands =
     python -VV
     mkdir -p {toxinidir}/_build/docs
-    sphinx-build -b html -d _build/docs/doctrees docs _build/docs/html
+    sphinx-build -b html -d _build/plone6docs/doctrees docs _build/plone6docs/html
+#    sphinx-build -b doctest docs _build/docs/doctrees
+
+
+[testenv:docs]
+# Locally for Maurits this only works with Python 2.7.
+# Travis is happy with 3.7, not with 3.8 or 3.9.
+# So pick the right one in .travis.yml (or GitHub Actions).
+basepython = python
+skip_install = False
+usedevelop = True
+extras =
+    tests
+
+deps =
+    Sphinx
+
+commands =
+    python -VV
+    mkdir -p {toxinidir}/_build/docs
+    sphinx-build -b html -D html_theme=alabaster -d _build/docs/doctrees docs _build/docs/html
 #    sphinx-build -b doctest docs _build/docs/doctrees
 
 whitelist_externals =
     mkdir
+
 
 [testenv:towncrier]
 basepython = python


### PR DESCRIPTION
**Integration of plone.api documentation in new Plone 6 documentation**

The documentation team is working on the integration. The documentation of plone.api stays untouched, a conversion from restructuredText to markdown/myST is not necessary. Some additions are proposed in this pull request to have a preview of the documentation on every pull request with changes to plone.api documentation ('make netlify')

**Remarks**
Preparation of integration in Plone 6 documentation does not affect the current build of the documentation (tox -e docs) as 
- the new build has its own tox environment. 'tox -e plone6docs' (temporary. Can be switched on going live of Plone 6 documentation)
- the theme is changed to sphinx-book-theme, but the current build uses 'alabaster' like before (see tox environment 'docs').

I re-added a Makefile to have a 'make netlify' command for the Netlify preview.

