### PR TITLE
Do not require the request parameter to be specified

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -497,6 +497,22 @@ view = api.content.get_view(
 %
 % self.assertEqual(view.__name__, u'plone')
 
+Since version `2.0.0`, the `request` argument can be omitted.
+In that case the global request will be used.
+
+```python
+from plone import api
+portal = api.portal.get()
+view = api.content.get_view(
+    name='plone',
+    context=portal['about'],
+)
+```
+
+% invisible-code-block: python
+%
+% self.assertEqual(view.__name__, u'plone')
+
 ## Further reading
 
 For more information on possible flags and usage options please see the full {ref}`plone-api-content` specification.

--- a/docs/portal.md
+++ b/docs/portal.md
@@ -271,6 +271,21 @@ api.portal.show_message(message='Blueberries!', request=request)
 % self.assertEqual(len(show), 1)
 % self.assertTrue('Blueberries!' in show[0].message)
 
+Since version `2.0.0`, the `request` argument can be omitted.
+In that case the global request will be used.
+
+```python
+api.portal.show_message(message='Cranberries!')
+```
+
+% invisible-code-block: python
+%
+% from Products.statusmessages.interfaces import IStatusMessage
+% messages = IStatusMessage(request)
+% show = messages.show()
+% self.assertEqual(len(show), 2)
+% self.assertTrue('Cranberries!' in show[1].message)
+
 (portal-get-registry-record-example)=
 
 ## Get plone.app.registry record

--- a/news/412.feature
+++ b/news/412.feature
@@ -1,0 +1,1 @@
+Do not require the request parameter to be specified. If not specify fallback to the global request [ale-rt]

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -13,6 +13,7 @@ from Products.CMFCore.WorkflowCore import WorkflowException
 from zope.component import getMultiAdapter
 from zope.component import getSiteManager
 from zope.container.interfaces import INameChooser
+from zope.globalrequest import getRequest
 from zope.interface import Interface
 from zope.interface import providedBy
 
@@ -495,7 +496,7 @@ def enable_roles_acquisition(obj=None):
     plone_utils.acquireLocalRoles(obj, status=1)
 
 
-@required_parameters("name", "context", "request")
+@required_parameters("name", "context")
 def get_view(name=None, context=None, request=None):
     """Get a BrowserView object.
 
@@ -510,6 +511,8 @@ def get_view(name=None, context=None, request=None):
         :class:`~plone.api.exc.InvalidParameterError`
     :Example: :ref:`content-get-view-example`
     """
+    if request is None:
+        request = getRequest()
     # We do not use exceptionhandling to detect if the requested view is
     # available, because the __init__ of said view will contain
     # errors in client code.

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -232,7 +232,7 @@ def get_localized_time(datetime=None, long_format=False, time_only=False):
     )
 
 
-@required_parameters("message", "request")
+@required_parameters("message")
 def show_message(message=None, request=None, type="info"):
     """Display a status message.
 
@@ -246,6 +246,8 @@ def show_message(message=None, request=None, type="info"):
         ValueError
     :Example: :ref:`portal-show-message-example`
     """
+    if request is None:
+        request = getRequest()
     IStatusMessage(request).add(message, type=type)
 
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -1330,13 +1330,6 @@ class TestPloneApiContent(unittest.TestCase):
                 request=request,
             )
 
-        # request is required
-        with self.assertRaises(MissingParameterError):
-            api.content.get_view(
-                name="plone",
-                context=self.blog,
-            )
-
     def test_get_view(self):
         """Test the view."""
         request = self.layer["request"]

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -451,12 +451,9 @@ class TestPloneApiPortal(unittest.TestCase):
         with self.assertRaises(MissingParameterError):
             portal.show_message()
 
-        # message and request are required
+        # message is a required parameter
         with self.assertRaises(MissingParameterError):
             portal.show_message(request=self.layer["request"])
-
-        with self.assertRaises(MissingParameterError):
-            portal.show_message(message="Beer is brewing.")
 
     def test_show_message(self):
         """Test to see if message appears."""


### PR DESCRIPTION
The request parameter helpers:

- `plone.api.content.get_view`
- `plone.api.portal.show_message`

is now optional.

If not specify fallback to the global request.

Fixes #412