### PR TITLE
Fix the security context managers

### DIFF
--- a/news/374.bugfix
+++ b/news/374.bugfix
@@ -1,0 +1,2 @@
+Ensure that the security related context managers
+restore the context even if an error occurs.

--- a/src/plone/api/env.py
+++ b/src/plone/api/env.py
@@ -80,9 +80,10 @@ def _adopt_user(user):
     old_security_manager = getSecurityManager()
     newSecurityManager(getRequest(), user)
 
-    yield
-
-    setSecurityManager(old_security_manager)
+    try:
+        yield
+    finally:
+        setSecurityManager(old_security_manager)
 
 
 @required_parameters("roles")
@@ -120,9 +121,10 @@ def _adopt_roles(roles):
     security_manager = getSecurityManager()
     security_manager.addContext(overriding_context)
 
-    yield
-
-    security_manager.removeContext(overriding_context)
+    try:
+        yield
+    finally:
+        security_manager.removeContext(overriding_context)
 
 
 class _GlobalRoleOverridingContext:

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
     python -VV
     pip install -r requirements.txt
     pip list
-    {envbindir}/buildout -c /{toxinidir}/{env:BUILDOUT_FILE} buildout:directory={envdir} buildout:develop={toxinidir}
+    {envbindir}/buildout -c /{toxinidir}/{env:BUILDOUT_FILE} buildout:directory={envdir} buildout:develop={toxinidir} install test
     {envbindir}/buildout -c {toxinidir}/{env:BUILDOUT_FILE} buildout:directory={envdir} buildout:develop={toxinidir} annotate
     {envbindir}/test
 


### PR DESCRIPTION
Ensure that the security related context managers
restore the context even if an error occurs.

Fixes #374