### PR TITLE
Trigger build and deploy of Plone 6 documentation

### DIFF
--- a/.github/workflows/update_remote_docs.yml
+++ b/.github/workflows/update_remote_docs.yml
@@ -1,0 +1,19 @@
+name: Trigger build and deploy of Plone 6 documentation
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "docs/*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.DOCUMENTATION_BUILD_APPLICATION_KEY}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/plone/documentation/actions/workflows/update_submodule.yml/dispatches \
+          -d '{"ref": "6-dev"}'

--- a/news/496.doc
+++ b/news/496.doc
@@ -1,0 +1,3 @@
+Trigger a new deploy core Plone documentation when Volto documentation is updated 
+[esteele]
+


### PR DESCRIPTION
Calls an Action on the Plone 6 documentation repo that updates the documentation registry's submodules and triggers a new build and deploy of the Plone 6 docs.

Refs plone/documentation#1214