### PR TITLE
Pin Sphinx<5,>=3 due to sphinx-book-theme 0.3.3 requirement.

### DIFF
--- a/news/499.documentation
+++ b/news/499.documentation
@@ -1,0 +1,1 @@
+Pin Sphinx<5,>=3 due to sphinx-book-theme 0.3.3 requirement. [stevepiercy]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx<5,>=3  # sphinx-book-theme 0.3.3 has requirement sphinx<5,>=3
 sphinx-book-theme<=0.3.99
 myst-parser
 sphinx-autobuild


### PR DESCRIPTION
Refs: https://github.com/plone/documentation/issues/1407