### PR TITLE
Fix api.relation.delete by relation name, by source, by target (inste…

### DIFF
--- a/news/501.bugfix
+++ b/news/501.bugfix
@@ -1,0 +1,1 @@
+Fix deletion of relations by relation name. @ksuess

--- a/src/plone/api/relation.py
+++ b/src/plone/api/relation.py
@@ -281,7 +281,8 @@ def delete(source=None, target=None, relationship=None):
         query["to_id"] = intids.getId(target)
     if relationship is not None:
         query["from_attribute"] = relationship
-    for rel in relation_catalog.findRelations(query):
+    # We'll change the bucket in the loop
+    for rel in [rel for rel in relation_catalog.findRelations(query)]:
         source = rel.from_object
         from_attribute = rel.from_attribute
         field_and_schema = _get_field_and_schema_for_fieldname(
@@ -292,7 +293,7 @@ def delete(source=None, target=None, relationship=None):
             # The relationship is not the name of a dexterity field.
             # Only purge relation from relation-catalog.
             relation_catalog.unindex(rel)
-            return
+            continue
 
         target = rel.to_object
         field, _schema = field_and_schema

--- a/src/plone/api/tests/test_relation.py
+++ b/src/plone/api/tests/test_relation.py
@@ -272,6 +272,150 @@ class TestPloneApiRelation(unittest.TestCase):
         self.assertEqual(len(api.relation.get(source=self.about)), 2)
         self.assertEqual(len(self.about.relatedItems), 1)
 
+    def test_delete_by_relation(self):
+        """Test deleting relations by relation name."""
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.about,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        self.assertEqual(len(api.relation.get(source=self.about)), 2)
+
+        api.relation.delete(
+            relationship="relatedItems",
+        )
+        self.assertEqual(len(api.relation.get(source=self.about)), 0)
+        self.assertEqual(len(self.about.relatedItems), 0)
+
+    def test_delete_by_source_and_relation(self):
+        """Test deleting relations by source and relation name."""
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.about,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 3)
+
+        api.relation.delete(
+            source=self.about,
+            relationship="relatedItems",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 1)
+
+    def test_delete_by_target_and_relation(self):
+        """Test deleting relations by target and relation name."""
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.about,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="link",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 3)
+        self.assertEqual(len(api.relation.get(relationship="link")), 1)
+
+        api.relation.delete(
+            target=self.events,
+            relationship="relatedItems",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 1)
+        self.assertEqual(len(api.relation.get(relationship="link")), 1)
+
+    def test_delete_by_source(self):
+        """Test deleting relations by source."""
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="link",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="link",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 2)
+        self.assertEqual(len(api.relation.get(relationship="link")), 2)
+
+        api.relation.delete(
+            source=self.about,
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 1)
+        self.assertEqual(len(api.relation.get(relationship="link")), 1)
+
+    def test_delete_by_target(self):
+        """Test deleting relations by target."""
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.team,
+            target=self.events,
+            relationship="relatedItems",
+        )
+        api.relation.create(
+            source=self.about,
+            target=self.blog,
+            relationship="link",
+        )
+        api.relation.create(
+            source=self.blog,
+            target=self.events,
+            relationship="link",
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 3)
+        self.assertEqual(len(api.relation.get(relationship="link")), 2)
+
+        api.relation.delete(
+            target=self.events,
+        )
+        self.assertEqual(len(api.relation.get(relationship="relatedItems")), 1)
+        self.assertEqual(len(api.relation.get(relationship="link")), 1)
+
     def test_deleted_relation_is_purged(self):
         """Test that relations that have the name of a non-relation-field are purged."""
         relation_catalog = getUtility(ICatalog)


### PR DESCRIPTION
…ad of single relation defined by source, target, relation name)

Fix https://github.com/plone/plone.api/issues/501