### PR TITLE
Mockup TinyMCE settings: Remove unused AtD related views.

### DIFF
--- a/news/504.bugfix
+++ b/news/504.bugfix
@@ -1,0 +1,5 @@
+Mockup TinyMCE settings: Remove unused AtD related views.
+
+Fix a test which was checking for "checkDocument" among other available views.
+"checkDocument" was a TinyMCE endpoint for unmaintained "After the Deadline"
+plugin, which is now removed.

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -1406,7 +1406,6 @@ class TestPloneApiContent(unittest.TestCase):
         should_be_theres = (
             "adapter",
             "authenticator",
-            "checkDocument",
             "get_macros",
             "history",
             "plone",


### PR DESCRIPTION
Fix a test which was checking for "checkDocument" among other available views. "checkDocument" was a TinyMCE endpoint for unmaintained "After the Deadline" plugin, which is now removed.

Together:
https://github.com/plone/Products.CMFPlone/pull/3765
https://github.com/plone/plone.base/pull/33
https://github.com/plone/plone.api/pull/504

Jenkins:
https://jenkins.plone.org/job/pull-request-6.0-3.11/500