### PR TITLE
Enhance API docs of portal.translate to show that the domain is optio…

### DIFF
--- a/news/510.documentation
+++ b/news/510.documentation
@@ -1,0 +1,2 @@
+Enhance API docs of portal.translate to show that the domain is optional in some cases.
+[thet]

--- a/news/510.documentation
+++ b/news/510.documentation
@@ -1,2 +1,1 @@
 Enhance API docs of `portal.translate` to show that the domain is optional in some cases. @thet
-[thet]

--- a/news/510.documentation
+++ b/news/510.documentation
@@ -1,2 +1,2 @@
-Enhance API docs of portal.translate to show that the domain is optional in some cases.
+Enhance API docs of `portal.translate` to show that the domain is optional in some cases. @thet
 [thet]

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -408,7 +408,7 @@ def translate(msgid, domain="plone", lang=None):
 
     :param msgid: [required] message to translate
     :type msgid: string | zope.i18nmessageid.Message
-    :param domain: i18n domain to use. When `msgid` is a instance of `Message`
+    :param domain: i18n domain to use. When ``msgid`` is an instance of ``Message``,
                    the Message' domain is used.
     :type domain: string
     :param lang: target language

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -407,7 +407,8 @@ def translate(msgid, domain="plone", lang=None):
     Default to current negotiated language if no target language specified.
 
     :param msgid: [required] message to translate
-    :type msgid: string | zope.i18nmessageid.Message
+    :type msgid: string
+    :type msgid: zope.i18nmessageid.Message
     :param domain: i18n domain to use. When ``msgid`` is an instance of ``Message``,
                    then the ``Message``'s domain is used.
     :type domain: string

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -409,7 +409,7 @@ def translate(msgid, domain="plone", lang=None):
     :param msgid: [required] message to translate
     :type msgid: string | zope.i18nmessageid.Message
     :param domain: i18n domain to use. When ``msgid`` is an instance of ``Message``,
-                   the Message' domain is used.
+                   then the ``Message``'s domain is used.
     :type domain: string
     :param lang: target language
     :type lang: string

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -407,8 +407,9 @@ def translate(msgid, domain="plone", lang=None):
     Default to current negotiated language if no target language specified.
 
     :param msgid: [required] message to translate
-    :type msgid: string
-    :param domain: i18n domain to use
+    :type msgid: string | zope.i18nmessageid.Message
+    :param domain: i18n domain to use. When `msgid` is a instance of `Message`
+                   the Message' domain is used.
     :type domain: string
     :param lang: target language
     :type lang: string


### PR DESCRIPTION
…nal in some cases.

If anyone can point me to some documentation on the api doc syntax, I'd be happy. Didn't found anything than docs on how to use sphinx autodoc on an API level and so forth.