### PR TITLE
Do not run GitHub Actions tests twice.

### DIFF
--- a/.github/workflows/plone_python.yml
+++ b/.github/workflows/plone_python.yml
@@ -2,7 +2,13 @@ name: Plone backend tests
 
 on:
   push:
+    branches:
+      - master
+      - main
   pull_request:
+    branches:
+      - master
+      - main
 
 jobs:
   plone_python:

--- a/news/0000.bugfix
+++ b/news/0000.bugfix
@@ -1,0 +1,5 @@
+Do not run GitHub Actions tests twice.
+Only run GitHub Actions tests when commiting directly against master or main or
+opening a pull request agains master or main. This avoids to run the same test
+suite for the same environment twice.
+[thet]


### PR DESCRIPTION
Only run GitHub Actions tests when commiting directly against master or main or opening a pull request agains master or main. This avoids to run the same test suite for the same environment twice.