### PR TITLE
Issue 312; Unrestricted find

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -195,13 +195,13 @@ documents = api.content.find(
 %
 % self.assertGreater(len(documents), 0)
 
-Find all Documents, and use unrestrictedSearchResults:
+Find all `Document` content types, and use unrestricted search results:
 
 ```python
 from plone import api
 documents = api.content.find(
     context=api.portal.get(),
-    portal_type='Document',
+    portal_type="Document",
     unrestricted=True,
 )
 ```

--- a/docs/content.md
+++ b/docs/content.md
@@ -195,6 +195,21 @@ documents = api.content.find(
 %
 % self.assertGreater(len(documents), 0)
 
+Find all Documents, and use unrestrictedSearchResults:
+
+```python
+from plone import api
+documents = api.content.find(
+    context=api.portal.get(),
+    portal_type='Document',
+    unrestricted=True,
+)
+```
+
+% invisible-code-block: python
+%
+% self.assertGreater(len(documents), 0)
+
 More information about how to use the catalog may be found in the
 [Plone Documentation](https://5.docs.plone.org/develop/plone/searching_and_indexing/index.html).
 

--- a/news/312.implementation
+++ b/news/312.implementation
@@ -1,1 +1,1 @@
-Implemented unrestricted find.
+Implemented unrestricted find of content types. @gogobd

--- a/news/312.implementation
+++ b/news/312.implementation
@@ -1,0 +1,1 @@
+Implemented unrestricted find.

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -653,7 +653,7 @@ def find(context=None, depth=None, untestricted=False, **kwargs):
     if not valid_indexes:
         return []
 
-    if kwargs.get("unrestricted"):
+    if unrestricted:
         return catalog.unrestrictedSearchResults(**query)
     else:
         return catalog(**query)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -599,7 +599,7 @@ def _parse_object_provides_query(query):
     return result
 
 
-def find(context=None, depth=None, untestricted=False, **kwargs):
+def find(context=None, depth=None, unrestricted=False, **kwargs):
     """Find content in the portal.
 
     :param context: Context for the search

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -652,4 +652,7 @@ def find(context=None, depth=None, **kwargs):
     if not valid_indexes:
         return []
 
-    return catalog(**query)
+    if kwargs.get('unrestricted'):
+        return catalog.unrestrictedSearchResults(**query)
+    else:
+        return catalog(**query)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -652,7 +652,7 @@ def find(context=None, depth=None, **kwargs):
     if not valid_indexes:
         return []
 
-    if kwargs.get('unrestricted'):
+    if kwargs.get("unrestricted"):
         return catalog.unrestrictedSearchResults(**query)
     else:
         return catalog(**query)

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -599,12 +599,13 @@ def _parse_object_provides_query(query):
     return result
 
 
-def find(context=None, depth=None, **kwargs):
+def find(context=None, depth=None, untestricted=False, **kwargs):
     """Find content in the portal.
 
     :param context: Context for the search
     :type obj: Content object
     :param depth: How far in the content tree we want to search from context
+    :param unrestricted: Boolean, use unrestrictedSearchResults if True
     :type obj: Content object
     :returns: Catalog brains
     :rtype: List

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -912,6 +912,13 @@ class TestPloneApiContent(unittest.TestCase):
         documents = api.content.find(portal_type="Document")
         self.assertEqual(len(documents), 2)
 
+    def test_find(self):
+        """Test the finding of content in various ways."""
+
+        # Find documents
+        documents = api.content.find(portal_type="Document", unrestricted=True)
+        self.assertEqual(len(documents), 2)
+
     def test_find_empty_query(self):
         """Make sure an empty query yields no results"""
 

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -912,8 +912,8 @@ class TestPloneApiContent(unittest.TestCase):
         documents = api.content.find(portal_type="Document")
         self.assertEqual(len(documents), 2)
 
-    def test_find(self):
-        """Test the finding of content in various ways."""
+    def test_untrestricted_find(self):
+        """Test the finding of content in with unrestricted search."""
 
         # Find documents
         documents = api.content.find(portal_type="Document", unrestricted=True)


### PR DESCRIPTION
Fix #312

Maybe we want this; unrestricted find is necessary because proxy roles are not being handled correctly atm.