### PR TITLE
Fix 'api.portal.translate' usage with country-specific language codes

### DIFF
--- a/news/524.bugfix
+++ b/news/524.bugfix
@@ -1,0 +1,1 @@
+Fix `api.portal.translate` usage with country-specific language codes [@ericof]

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -21,6 +21,7 @@ from zope.interface.interfaces import IInterface
 import datetime as dtime
 import re
 
+
 logger = getLogger("plone.api.portal")
 
 try:

--- a/src/plone/api/portal.py
+++ b/src/plone/api/portal.py
@@ -19,7 +19,7 @@ from zope.globalrequest import getRequest
 from zope.interface.interfaces import IInterface
 
 import datetime as dtime
-
+import re
 
 logger = getLogger("plone.api.portal")
 
@@ -419,6 +419,8 @@ def translate(msgid, domain="plone", lang=None):
     :Example: :ref:`portal-translate-example`
     """
     translation_service = get_tool("translation_service")
+    if lang and re.match(r"\D{2}-\D{2}", lang):
+        lang = f"{lang[:2]}_{lang[-2:].upper()}"
     query = {
         "msgid": msgid,
         "domain": domain,

--- a/src/plone/api/tests/test_portal.py
+++ b/src/plone/api/tests/test_portal.py
@@ -886,3 +886,20 @@ class TestPloneApiPortal(unittest.TestCase):
             ),
             "Avril",
         )
+
+    def test_translate_with_country_codes(self):
+        """Test translation."""
+        self.assertEqual(
+            portal.translate(
+                "Page",
+                lang="pt-br",
+            ),
+            "Página",
+        )
+        self.assertEqual(
+            portal.translate(
+                "Page",
+                lang="pt_BR",
+            ),
+            "Página",
+        )


### PR DESCRIPTION
Fixes #524