### PR TITLE
Enhance Path Handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+CURRENT_DIR:="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"
 
 version = 3
 

--- a/news/530.bugfix
+++ b/news/530.bugfix
@@ -1,0 +1,1 @@
+Enhanced Makefile paths to address whitespace compatibility issues. @Vivek-04022001


### PR DESCRIPTION
Issue Description:

The Makefile uses realpath to set **CURRENT_DIR**:
```
CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

```
replace with 
```
CURRENT_DIR:="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

```
This can cause compatibility issues and doesn't handle special characters in paths. We need to replace realpath with a more portable and robust method. **This issues was already discussed with @stevepiercy on plone community** [conversation link](https://community.plone.org/t/error-running-training-repo-seek-advice-on-pull-request/18618/8?u=vivek-04022001)