### PR TITLE
Use correct syntax for `no-index`

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -9,7 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
-    :noindex:
+    :no-index:
 ```
 
 (chapter-env)=

--- a/docs/group.md
+++ b/docs/group.md
@@ -9,7 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
-    :noindex:
+    :no-index:
 ```
 
 (chapter-groups)=

--- a/docs/portal.md
+++ b/docs/portal.md
@@ -9,7 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
-    :noindex:
+    :no-index:
 ```
 
 (chapter-portal)=

--- a/docs/relation.md
+++ b/docs/relation.md
@@ -9,7 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
-    :noindex:
+    :no-index:
 ```
 
 (chapter-relation)=

--- a/docs/user.md
+++ b/docs/user.md
@@ -9,7 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
-    :noindex:
+    :no-index:
 ```
 
 (chapter-users)=

--- a/news/540.documentation
+++ b/news/540.documentation
@@ -1,0 +1,1 @@
+Use correct syntax for `no-index` in documentation. @stevepiercy


### PR DESCRIPTION
This fixes errors like:

```
/plone.api/docs/group.md:11: WARNING: duplicate object description of plone, other instance in content, use :no-index: for one of them
```