### PR TITLE
Remove references to non-functional Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,3 @@ Issues
 Continuous Integration
     tested on [GitHub Actions](https://github.com/plone/plone.api/actions).
 
-Code Coverage
-    is measured at [Coveralls.io](https://coveralls.io/github/plone/plone.api).
-

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -241,4 +241,3 @@ The documentation is rendered with a link from the API reference to the narrativ
 -   {doc}`plone:index`
 -   [Source code](https://github.com/plone/plone.api)
 -   [Issue tracker](https://github.com/plone/plone.api/issues)
--   [Code Coverage](https://coveralls.io/github/plone/plone.api)

--- a/news/543.documentation
+++ b/news/543.documentation
@@ -1,0 +1,1 @@
+Remove references to unused Coveralls. @stevepiercy


### PR DESCRIPTION
Coveralls has not worked since Travis CI was removed back in 2021(?). Documentation still shows it is being used. It hasn't been missed.

- Closes #537
- See #233, which I think should be closed.