### PR TITLE
Use Read the Docs for pull request previews

### DIFF
--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -1,0 +1,22 @@
+# .github/workflows/rtd-pr-preview.yml
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "ploneapi"
+          single-version: "true"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  commands:
+    # Cancel building pull requests when there aren't changes in the docs directory or YAML file.
+    # You can add any other files or directories that you'd like here as well,
+    # like your docs requirements file, or other files that will change your docs build.
+    #
+    # If there are no changes (git diff exits with 0) we force the command to return with 183.
+    # This is a special exit code on Read the Docs that will cancel the build immediately.
+    - |
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml requirements-docs.txt requirements.txt;
+      then
+        exit 183;
+      fi
+    - tox -e plone6docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
   commands:
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.
     # You can add any other files or directories that you'd like here as well,

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,6 @@ build:
       then
         exit 183;
       fi
+    - pip install -r requirements.txt
+    - pip install -r requirements-docs.txt
     - tox -e plone6docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,5 +23,5 @@ build:
         exit 183;
       fi
     - pip install -r requirements.txt
-    - pip install -r requirements-docs.txt
-    - tox -e plone6docs
+#    - pip install -r requirements-docs.txt
+    - tox -e rtd-preview

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ include pyproject.toml
 recursive-exclude news *
 exclude news
 recursive-exclude .vscode *
+exclude .readthedocs.yaml
 
 # added by check-manifest
 recursive-include src *.py

--- a/news/545.documentation
+++ b/news/545.documentation
@@ -1,0 +1,1 @@
+Preview docs on Read the Docs instead of Netlify. @stevepiercy

--- a/tox.ini
+++ b/tox.ini
@@ -285,8 +285,7 @@ deps =
     -r requirements-docs.txt
 commands =
     python -VV
-    mkdir -p {toxinidir}/$READTHEDOCS_OUTPUT
-    sphinx-build -b html -d $READTHEDOCS_OUTPUT/doctrees/ docs $READTHEDOCS_OUTPUT/html/
+    sphinx-build -b html -d "{env:READTHEDOCS_OUTPUT}"/doctrees/ docs "{env:READTHEDOCS_OUTPUT}"/html/"
 
 [testenv:docs]
 basepython = python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -271,6 +271,23 @@ commands =
     mkdir -p {toxinidir}/_build/plone6docs
     sphinx-build -b html -d _build/plone6docs/doctrees docs _build/plone6docs/html
 
+[testenv:rtd-preview]
+# New docs with sphinx-book-theme
+# See [testenv:docs] for classic documentation
+basepython = python3.11
+skip_install = False
+package = editable
+allowlist_externals =
+    mkdir
+extras =
+    tests
+deps =
+    -r requirements-docs.txt
+commands =
+    python -VV
+    mkdir -p {toxinidir}/${READTHEDOCS_OUTPUT}
+    sphinx-build -b html -d ${READTHEDOCS_OUTPUT}/doctrees/ docs ${READTHEDOCS_OUTPUT}/html/
+
 [testenv:docs]
 basepython = python3.9
 skip_install = False

--- a/tox.ini
+++ b/tox.ini
@@ -285,7 +285,7 @@ deps =
     -r requirements-docs.txt
 commands =
     python -VV
-    sphinx-build -b html -d "{env:READTHEDOCS_OUTPUT}"/doctrees/ docs "{env:READTHEDOCS_OUTPUT}"/html/"
+    sphinx-build -b html -d "{env:READTHEDOCS_OUTPUT}"/doctrees/ docs "{env:READTHEDOCS_OUTPUT}"/html/
 
 [testenv:docs]
 basepython = python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -285,8 +285,8 @@ deps =
     -r requirements-docs.txt
 commands =
     python -VV
-    mkdir -p {toxinidir}/${READTHEDOCS_OUTPUT}
-    sphinx-build -b html -d ${READTHEDOCS_OUTPUT}/doctrees/ docs ${READTHEDOCS_OUTPUT}/html/
+    mkdir -p {toxinidir}/$READTHEDOCS_OUTPUT
+    sphinx-build -b html -d $READTHEDOCS_OUTPUT/doctrees/ docs $READTHEDOCS_OUTPUT/html/
 
 [testenv:docs]
 basepython = python3.9


### PR DESCRIPTION
This pull request replaces the Netlify pull request preview build which supports only Python 3.8.