### PR TITLE
Fix api.content.get when a item in the path is not acccessible

### DIFF
--- a/news/549.bugfix
+++ b/news/549.bugfix
@@ -1,0 +1,2 @@
+Fix api.content.get(path=path) when a item in the path is not accessible to the user.
+[pbauer]

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -133,7 +133,12 @@ def get(path=None, UID=None):
                 relative_path=path,
             )
         try:
-            content = site.restrictedTraverse(path)
+            path = path.split("/")
+            if len(path) > 1:
+                parent = site.unrestrictedTraverse(path[:-1])
+                content = parent.restrictedTraverse(path[-1])
+            else:
+                content = site.restrictedTraverse(path[-1])
         except (KeyError, AttributeError):
             return None  # When no object is found don't raise an error
         else:

--- a/src/plone/api/tests/test_content.py
+++ b/src/plone/api/tests/test_content.py
@@ -478,6 +478,16 @@ class TestPloneApiContent(unittest.TestCase):
         # title is an attribute
         self.assertIsNone(api.content.get("/about/team/title"))
 
+    def test_get_of_content_in_inaccessible_container(self):
+        """Test getting items in a inaccessible container.
+        Worked in Plone 5.1 but raised Unauthorized since 5.2."""
+        api.content.transition(obj=self.team, transition="publish")
+        with api.env.adopt_roles(["Member"]):
+            team_by_path = api.content.get("/about/team")
+            self.assertEqual(self.team, team_by_path)
+            team_by_uid = api.content.get(UID=self.team.UID())
+            self.assertEqual(self.team, team_by_uid)
+
     def test_move_constraints(self):
         """Test the constraints for moving content."""
         from plone.api.exc import MissingParameterError


### PR DESCRIPTION
Fixes #549

<!-- readthedocs-preview ploneapi start -->
----
📚 Documentation preview 📚: https://ploneapi--550.org.readthedocs.build/

<!-- readthedocs-preview ploneapi end -->