### PR TITLE
 Issue #532: Implement get_path helper API 

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -536,6 +536,57 @@ view = api.content.get_view(
 %
 % self.assertEqual(view.__name__, u'plone')
 
+(content-get-path-example)=
+
+## Get content path
+
+To get the path of a content object, use {meth}`api.content.get_path`. This method returns either an absolute path from the Zope root or a relative path from the portal root.
+
+To get absolute path from the Zope root.
+
+```python
+from plone import api
+portal = api.portal.get()
+
+folder = portal['events']['training']
+path = api.content.get_path(obj=folder)
+assert path == '/plone/events/training'
+```
+
+To get portal-relative path.
+
+```python
+rel_path = api.content.get_path(obj=folder, relative_to_portal=True)
+assert rel_path == '/events/training'
+```
+
+If the API is used to fetch an object outside portal, with {meth}`relative_to_portal` parameter as `True`, it throws a `InvalidParameterError`
+
+% invisible-code-block: python
+%
+% # Setup an object outside portal for testing error case
+% app = portal.aq_parent
+% app.manage_addFolder('outside_folder')
+%
+% # Test that getting relative path for object outside portal raises error
+% from plone.api.exc import InvalidParameterError
+% with self.assertRaises(InvalidParameterError):
+%     api.content.get_path(obj=app.outside_folder, relative_to_portal=True)
+
+```python
+from plone.api.exc import InvalidParameterError
+
+# Getting path of an object outside portal raises InvalidParameterError
+try:
+    outside_path = api.content.get_path(
+        obj=app.outside_folder,
+        relative_to_portal=True
+    )
+    assert False, "Should raise InvalidParameterError & not reach this code"
+except InvalidParameterError as e:
+    assert "Object not in portal path" in str(e)
+```
+
 ## Further reading
 
 For more information on possible flags and usage options please see the full {ref}`plone-api-content` specification.

--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -569,6 +569,36 @@ def get_uuid(obj=None):
     return IUUID(obj)
 
 
+@required_parameters("obj")
+def get_path(obj=None, relative_to_portal=False):
+    """Get the path of an object.
+
+    :param obj: [required] Object we want to get the path for
+    :type obj: Content object
+    :param relative_to_portal: Return a relative path from the portal root
+    :type relative_to_portal: boolean
+    :returns: Path to the object
+    :rtype: string
+    :raises:
+        InvalidParameterError
+    :Example: :ref:`content-get-path-example`
+    """
+    if not hasattr(obj, "getPhysicalPath"):
+        raise InvalidParameterError(f"Cannot get path of object of type {type(obj)}")
+
+    if relative_to_portal:
+        site = portal.get()
+        site_path = site.getPhysicalPath()
+        obj_path = obj.getPhysicalPath()
+        if obj_path[: len(site_path)] != site_path:
+            raise InvalidParameterError(
+                "Object not in portal path. Object path: {}".format("/".join(obj_path))
+            )
+        rel_path = obj_path[len(site_path) :]
+        return "/" + "/".join(rel_path) if rel_path else "/"
+    return "/" + "/".join(obj.getPhysicalPath()[1:])
+
+
 def _parse_object_provides_query(query):
     """Create a query for the object_provides index.
 


### PR DESCRIPTION
Fixes Issue #532 

- Uses Zope's inbuilt getPhysicalPath internally.
- optional parameter `relative_to_portal` to fetch patch relative to Plone portal
- throws `InvalidParameterError` when used to fetch an object outside of Plone portal with `relative_to_portal` parameter set to True