### PR TITLE
Fix broken reference to get-closest-ancestor-example

### DIFF
--- a/src/plone/api/content.py
+++ b/src/plone/api/content.py
@@ -782,7 +782,7 @@ def get_closest_ancestor(obj=None, function=None, interface=None, stop_at=_marke
     :type stop_at: Content object or False
     :returns: Iterator of ancestor objects, from immediate to site root.
     :rtype: iterator
-    :Example: :ref:`get-closest-ancestors-example`
+    :Example: :ref:`get-closest-ancestor-example`
     """
     return next(
         iter_ancestors(


### PR DESCRIPTION
I think a news item is not required because it was a mere typo in the ref to `get-closest-ancestor-example` and a follow up to https://github.com/plone/plone.api/pull/562. If needed, I'll add a news item.

<!-- readthedocs-preview ploneapi start -->
----
📚 Documentation preview 📚: https://ploneapi--572.org.readthedocs.build/

<!-- readthedocs-preview ploneapi end -->