### PR TITLE
Fix version pinning for tox environments

### DIFF
--- a/constraints_plone52.txt
+++ b/constraints_plone52.txt
@@ -1,1 +1,1 @@
--c https://dist.plone.org/release/5.2-latest/requirements.txt
+-c https://dist.plone.org/release/5.2-latest/constraints.txt

--- a/constraints_plone60.txt
+++ b/constraints_plone60.txt
@@ -1,1 +1,1 @@
--c https://dist.plone.org/release/6.0-latest/requirements.txt
+-c https://dist.plone.org/release/6.0-latest/constraints.txt

--- a/news/571.internal
+++ b/news/571.internal
@@ -1,0 +1,1 @@
+Fix CI. @davisagli

--- a/tox.ini
+++ b/tox.ini
@@ -319,6 +319,7 @@ commands =
 [testenv:livehtml]
 basepython = python3.11
 skip_install = False
+constrain_package_deps = true
 package = editable
 allowlist_externals =
     mkdir
@@ -326,6 +327,7 @@ extras =
     {[testenv:plone6docs]extras}
 deps =
     {[testenv:plone6docs]deps}
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
     python -VV
     mkdir -p {toxinidir}/_build/plone6docs

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,8 @@ set_env =
 #  constrain_package_deps = "false"
 ##
 deps =
-    zope.testrunner -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -165,7 +166,8 @@ set_env =
 ##
 deps =
     coverage
-    zope.testrunner -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 commands =
     coverage run --branch --source plone.api {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s plone.api {posargs}


### PR DESCRIPTION
Fixes #571 

The constraints were not applied correctly.

<!-- readthedocs-preview ploneapi start -->
----
📚 Documentation preview 📚: https://ploneapi--573.org.readthedocs.build/

<!-- readthedocs-preview ploneapi end -->