### PR TITLE
Fix link in README to Contributing to `plone.api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Recipes try to assume the user does not have extensive knowledge about Plone int
 
 
 Contributors
-    Please read [Contributing to Plone](https://6.docs.plone.org/contributing/index.html) and [Contributing to `plone.api`](https://6.docs.plone.org/plone.api/contribute/index.html).
+    Please read [Contributing to Plone](https://6.docs.plone.org/contributing/index.html) and [Contributing to `plone.api`](https://6.docs.plone.org/plone.api/contribute.html).
 
 Source Code
     at the [Plone code repository hosted at GitHub](https://github.com/plone/plone.api).

--- a/news/575.documentation
+++ b/news/575.documentation
@@ -1,0 +1,1 @@
+Fix link in README to Contributing to `plone.api`. @stevepiercy


### PR DESCRIPTION


<!-- readthedocs-preview ploneapi start -->
----
📚 Documentation preview 📚: https://ploneapi--575.org.readthedocs.build/

<!-- readthedocs-preview ploneapi end -->