### PR TITLE
Resolve Sphinx warning `duplicate object description of plone`

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -9,6 +9,7 @@ myst:
 
 ```{eval-rst}
 .. module:: plone
+    :no-index:
 ```
 
 (chapter-content)=


### PR DESCRIPTION
This PR resolves the following warning when building the docs.

`plone.api/content.md:11: WARNING: duplicate object description of plone, other instance in plone.api/addon, use :no-index: for one of them`