### PR TITLE
Make UserNotFoundError more informative

### DIFF
--- a/news/585.bugfix.md
+++ b/news/585.bugfix.md
@@ -1,0 +1,1 @@
+Make plone.api.exc.UserNotFoundError message more informative by including the not found username [@ale-rt]

--- a/src/plone/api/env.py
+++ b/src/plone/api/env.py
@@ -59,7 +59,7 @@ def adopt_user(username=None, user=None):
                 user = unwrapped.__of__(acl_users)
                 break
         else:
-            raise UserNotFoundError
+            raise UserNotFoundError(username)
 
     return _adopt_user(user)
 

--- a/src/plone/api/group.py
+++ b/src/plone/api/group.py
@@ -85,7 +85,7 @@ def get_groups(username=None, user=None):
     if username:
         user = user_get(username=username)
         if not user:
-            raise UserNotFoundError
+            raise UserNotFoundError(username)
 
     group_tool = portal.get_tool("portal_groups")
 
@@ -157,7 +157,7 @@ def add_user(groupname=None, group=None, username=None, user=None):
     if username:
         user = user_get(username=username)
         if not user:
-            raise UserNotFoundError
+            raise UserNotFoundError(username)
 
     user_id = user.id
     group_id = groupname or group.id
@@ -194,7 +194,7 @@ def remove_user(groupname=None, group=None, username=None, user=None):
     if username:
         user = user_get(username=username)
         if not user:
-            raise UserNotFoundError
+            raise UserNotFoundError(username)
     user_id = user.id
     group_id = groupname or group.id
     portal_groups = portal.get_tool("portal_groups")

--- a/src/plone/api/tests/test_group.py
+++ b/src/plone/api/tests/test_group.py
@@ -152,8 +152,9 @@ class TestPloneApiGroup(unittest.TestCase):
         """Test retrieving of groups for a user that does not exist."""
         from plone.api.exc import UserNotFoundError
 
-        with self.assertRaises(UserNotFoundError):
+        with self.assertRaises(UserNotFoundError) as exc:
             api.group.get_groups(username="theurbanspaceman")
+        self.assertEqual(str(exc.exception), "theurbanspaceman")
 
     def test_get_groups_anonymous(self):
         from AccessControl.users import nobody
@@ -239,8 +240,9 @@ class TestPloneApiGroup(unittest.TestCase):
         """Test adding a user that does not exist to a group."""
         from plone.api.exc import UserNotFoundError
 
-        with self.assertRaises(UserNotFoundError):
+        with self.assertRaises(UserNotFoundError) as exc:
             api.group.add_user(username="jane", groupname="staff")
+        self.assertEqual(str(exc.exception), "jane")
 
     def test_add_user_username(self):
         """Test adding a user to a group by username."""
@@ -327,8 +329,9 @@ class TestPloneApiGroup(unittest.TestCase):
 
         api.group.create(groupname="staff")
         group = api.group.get(groupname="staff")
-        with self.assertRaises(UserNotFoundError):
+        with self.assertRaises(UserNotFoundError) as exc:
             api.group.remove_user(group=group, username="iamnothere")
+        self.assertEqual(str(exc.exception), "iamnothere")
 
     def test_grant_roles(self):
         """Test grant roles."""

--- a/src/plone/api/tests/test_user.py
+++ b/src/plone/api/tests/test_user.py
@@ -342,8 +342,9 @@ class TestPloneApiUser(unittest.TestCase):
         """Test get roles for a user that does not exist."""
         from plone.api.exc import UserNotFoundError
 
-        with self.assertRaises(UserNotFoundError):
+        with self.assertRaises(UserNotFoundError) as exc:
             api.user.get_roles(username="theurbanspaceman")
+        self.assertEqual(str(exc.exception), "theurbanspaceman")
 
     def test_get_roles_anonymous(self):
         """Test get_roles for an anonymous user."""
@@ -509,8 +510,9 @@ class TestPloneApiUser(unittest.TestCase):
         """Test get_permissions for a user that does not exist."""
         from plone.api.exc import UserNotFoundError
 
-        with self.assertRaises(UserNotFoundError):
+        with self.assertRaises(UserNotFoundError) as exc:
             api.user.get_permissions(username="ming")
+        self.assertEqual(str(exc.exception), "ming")
 
     def test_get_permissions_context(self):
         """Test get permissions on some context."""

--- a/src/plone/api/user.py
+++ b/src/plone/api/user.py
@@ -232,7 +232,7 @@ def get_roles(username=None, user=None, obj=None, inherit=True):
         user = portal_membership.getMemberById(username)
 
     if user is None:
-        raise UserNotFoundError(username or user and user.getUserName())
+        raise UserNotFoundError(username)
 
     if obj is not None:
         if inherit:

--- a/src/plone/api/user.py
+++ b/src/plone/api/user.py
@@ -232,7 +232,7 @@ def get_roles(username=None, user=None, obj=None, inherit=True):
         user = portal_membership.getMemberById(username)
 
     if user is None:
-        raise UserNotFoundError
+        raise UserNotFoundError(username or user and user.getUserName())
 
     if obj is not None:
         if inherit:


### PR DESCRIPTION
Make plone.api.exc.UserNotFoundError message more informative by including the not found username

Fixes #585 